### PR TITLE
Fix integer datatypes on 32-bit systems

### DIFF
--- a/src/c/rasta_init.c
+++ b/src/c/rasta_init.c
@@ -1,16 +1,17 @@
-#include <rasta/rasta_init.h>
+#include <memory.h>
+#include <stdbool.h>
 
-#include "retransmission/protocol.h"
+#include <rasta/rasta_init.h>
+#include <rasta/rastautil.h>
+#include <rasta/rmemory.h>
+
 #include "retransmission/safety_retransmission.h"
 #include "transport/events.h"
 #include "transport/transport.h"
-#include <memory.h>
-#include <rasta/rmemory.h>
-#include <stdbool.h>
 
-// This is the time that packets are deferred for creating multi-packet messages
+// This is the time that packets are deferred for creating multi-packet messages (in ms)
 // See section 5.5.10
-#define IO_INTERVAL 10000
+#define IO_INTERVAL 10
 
 void init_connection_timeout_event(timed_event *ev, struct timed_event_data *carry_data,
                                    struct rasta_connection *connection) {
@@ -105,7 +106,7 @@ void rasta_lib_init_configuration(rasta_lib_configuration_t user_configuration, 
         // batch outgoing packets
         memset(&connection->send_handle.send_event, 0, sizeof(timed_event));
         connection->send_handle.send_event.callback = data_send_event;
-        connection->send_handle.send_event.interval = IO_INTERVAL * 1000lu;
+        connection->send_handle.send_event.interval = IO_INTERVAL * NS_PER_MS;
         connection->send_handle.send_event.carry_data = &connection->send_handle;
         connection->send_handle.connection = connection;
 

--- a/src/c/rasta_init.c
+++ b/src/c/rasta_init.c
@@ -1,12 +1,12 @@
 #include <rasta/rasta_init.h>
 
-#include <memory.h>
-#include <stdbool.h>
-#include <rasta/rmemory.h>
-#include "transport/transport.h"
-#include "transport/events.h"
 #include "retransmission/protocol.h"
 #include "retransmission/safety_retransmission.h"
+#include "transport/events.h"
+#include "transport/transport.h"
+#include <memory.h>
+#include <rasta/rmemory.h>
+#include <stdbool.h>
 
 // This is the time that packets are deferred for creating multi-packet messages
 // See section 5.5.10
@@ -17,7 +17,7 @@ void init_connection_timeout_event(timed_event *ev, struct timed_event_data *car
     memset(ev, 0, sizeof(timed_event));
     ev->callback = event_connection_expired;
     ev->carry_data = carry_data;
-    ev->interval = connection->config->sending.t_max * 1000000lu;
+    ev->interval = connection->config->sending.t_max * NS_PER_MS;
     carry_data->handle = &connection->heartbeat_handle;
     carry_data->connection = connection;
 }
@@ -27,7 +27,7 @@ void init_send_heartbeat_event(timed_event *ev, struct timed_event_data *carry_d
     memset(ev, 0, sizeof(timed_event));
     ev->callback = heartbeat_send_event;
     ev->carry_data = carry_data;
-    ev->interval = connection->config->sending.t_h * 1000000lu;
+    ev->interval = connection->config->sending.t_h * NS_PER_MS;
     carry_data->handle = &connection->heartbeat_handle;
     carry_data->connection = connection;
 }
@@ -140,6 +140,6 @@ void rasta_lib_init_configuration(rasta_lib_configuration_t user_configuration, 
 
         init_connection_events(h, connection);
     }
-    
+
     h->rasta_connections_length = connections_length;
 }

--- a/src/c/retransmission/protocol.c
+++ b/src/c/retransmission/protocol.c
@@ -1,8 +1,12 @@
+#include <stdlib.h>
+#include <time.h>
+
+#include <rasta/config.h>
+#include <rasta/rastautil.h>
+
 #include "protocol.h"
 
-#include <time.h>
-#include <stdlib.h>
-#include <rasta/config.h>
+// TODO: This contains mostly utility functions, like rastautil.c. Merge these two files?
 
 uint64_t get_current_time_ms() {
     uint64_t current_time;

--- a/src/c/retransmission/protocol.h
+++ b/src/c/retransmission/protocol.h
@@ -1,16 +1,16 @@
 #pragma once
 
-#include <stdint.h>
 #include <rasta/config.h>
+#include <stdint.h>
 
 /**
  * the RaSTA version that is implemented
  */
 #define RASTA_VERSION "0303"
 
-#define NS_PER_SEC 1000000000
-#define MS_PER_S 1000
-#define NS_PER_MS 1000000
+#define NS_PER_SEC 1000000000ULL
+#define MS_PER_S 1000ULL
+#define NS_PER_MS 1000000ULL
 
 uint64_t get_current_time_ms();
 

--- a/src/c/retransmission/protocol.h
+++ b/src/c/retransmission/protocol.h
@@ -8,10 +8,6 @@
  */
 #define RASTA_VERSION "0303"
 
-#define NS_PER_SEC 1000000000ULL
-#define MS_PER_S 1000ULL
-#define NS_PER_MS 1000000ULL
-
 uint64_t get_current_time_ms();
 
 int compare_version(char (*local_version)[5], char (*remote_version)[5]);

--- a/src/c/transport/events.c
+++ b/src/c/transport/events.c
@@ -2,18 +2,18 @@
 #include <stdlib.h>
 
 #include <rasta/logging.h>
-#include <rasta/rmemory.h>
 #include <rasta/rasta.h>
 #include <rasta/rastahandle.h>
 #include <rasta/rastaredundancy.h>
+#include <rasta/rmemory.h>
 
-#include "diagnostics.h"
-#include "events.h"
-#include "transport.h"
 #include "../experimental/handlers.h"
 #include "../retransmission/messages.h"
 #include "../retransmission/protocol.h"
 #include "../retransmission/safety_retransmission.h"
+#include "diagnostics.h"
+#include "events.h"
+#include "transport.h"
 
 int channel_accept_event(void *carry_data) {
     struct accept_event_data *data = carry_data;
@@ -31,7 +31,7 @@ int channel_accept_event(void *carry_data) {
 
     // Find the suitable transport channel in the mux
     find_channel_by_ip_address(data->h, addr, &red_channel_idx, &transport_channel_idx);
-    if(red_channel_idx != -1 && transport_channel_idx != -1){
+    if (red_channel_idx != -1 && transport_channel_idx != -1) {
         channel = &data->h->mux.redundancy_channels[red_channel_idx].transport_channels[transport_channel_idx];
     }
 
@@ -59,7 +59,7 @@ int channel_accept_event(void *carry_data) {
 
 int channel_receive_event(void *carry_data) {
     struct receive_event_data *data = carry_data;
-    rasta_connection * connection = data->connection;
+    rasta_connection *connection = data->connection;
 
     unsigned char buffer[MAX_DEFER_QUEUE_MSG_SIZE] = {0};
     struct sockaddr_in sender = {0};
@@ -206,13 +206,13 @@ int data_send_event(void *carry_data) {
         unsigned int send_backlog_size = sr_send_queue_item_count(con);
 
         // to prevent discarding packets, we can send at most as many packets as can be added to the retransmission queue
-        if(retransmission_available_size < send_backlog_size) {
+        if (retransmission_available_size < send_backlog_size) {
             send_backlog_size = retransmission_available_size;
         }
 
         if (send_backlog_size > 0) {
             logger_log(h->logger, LOG_LEVEL_DEBUG, "RaSTA send handler", "Messages waiting to be sent: %d",
-                        sr_send_queue_item_count(con));
+                       sr_send_queue_item_count(con));
 
             struct RastaMessageData app_messages;
             struct RastaByteArray msg;
@@ -223,15 +223,15 @@ int data_send_event(void *carry_data) {
             allocateRastaMessageData(&app_messages, send_backlog_size);
 
             logger_log(h->logger, LOG_LEVEL_DEBUG, "RaSTA send handler",
-                        "Sending %d application messages from queue",
-                        send_backlog_size);
+                       "Sending %d application messages from queue",
+                       send_backlog_size);
 
             for (unsigned int i = 0; i < send_backlog_size; i++) {
 
                 struct RastaByteArray *elem;
                 elem = fifo_pop(con->fifo_send);
                 logger_log(h->logger, LOG_LEVEL_DEBUG, "RaSTA send handler",
-                            "Adding application message to data packet");
+                           "Adding application message to data packet");
 
                 allocateRastaByteArray(&msg, elem->length);
                 msg.bytes = rmemcpy(msg.bytes, elem->bytes, elem->length);

--- a/src/c/util/event_system.c
+++ b/src/c/util/event_system.c
@@ -8,7 +8,7 @@
 uint64_t get_nanotime() {
     struct timespec t;
     clock_gettime(CLOCK_MONOTONIC, &t);
-    return t.tv_sec * 1000000000 + t.tv_nsec;
+    return t.tv_sec * NS_PER_S + t.tv_nsec;
 }
 
 int get_max_nfds(struct fd_event_linked_list_s *fd_events) {
@@ -30,8 +30,8 @@ int get_max_nfds(struct fd_event_linked_list_s *fd_events) {
  */
 int event_system_sleep(uint64_t time_to_wait, struct fd_event_linked_list_s *fd_events) {
     struct timeval tv;
-    tv.tv_sec = time_to_wait / 1000000000;
-    tv.tv_usec = (time_to_wait / 1000) % 1000000;
+    tv.tv_sec = time_to_wait / NS_PER_S;
+    tv.tv_usec = (time_to_wait / MS_PER_S) % NS_PER_MS;
     int nfds = get_max_nfds(fd_events);
     if (nfds >= FD_SETSIZE) {
         // too high file desriptors, can be fixed by using poll instead but should not be an issue
@@ -55,7 +55,7 @@ int event_system_sleep(uint64_t time_to_wait, struct fd_event_linked_list_s *fd_
         }
     }
     // wait
-    struct timeval* timeout = time_to_wait == UINT64_MAX ? NULL : &tv;
+    struct timeval *timeout = time_to_wait == UINT64_MAX ? NULL : &tv;
     int result = select(nfds, &on_readable, &on_writable, &on_exceptional, timeout);
     if (result == -1) {
         perror("select failed");

--- a/src/c/util/rastautil.c
+++ b/src/c/util/rastautil.c
@@ -1,8 +1,8 @@
 #include <stdlib.h>
 #include <time.h>
 
-#include <rasta/rmemory.h>
 #include <rasta/rastautil.h>
+#include <rasta/rmemory.h>
 
 #define rasta_htole32(X) (X)
 #define rasta_le32toh(X) (X)
@@ -21,7 +21,7 @@ uint32_t cur_timestamp() {
     s = spec.tv_sec;
 
     // seconds to milliseconds
-    ms = s * 1000;
+    ms = s * MS_PER_S;
 
     // nanoseconds to milliseconds
     ms += (long)(spec.tv_nsec / 1.0e6);

--- a/src/include/rasta/rastautil.h
+++ b/src/include/rasta/rastautil.h
@@ -1,14 +1,18 @@
 #pragma once
 
 #ifdef __cplusplus
-extern "C" {  // only need to export C interface if
-              // used by C++ source code
+extern "C" { // only need to export C interface if
+             // used by C++ source code
 #endif
 
 #include <stdint.h>
 
+#define NS_PER_S 1000000000ULL
+#define MS_PER_S 1000ULL
+#define NS_PER_MS 1000000ULL
+
 struct RastaByteArray {
-    unsigned char* bytes;
+    unsigned char *bytes;
     unsigned int length;
 };
 
@@ -16,14 +20,14 @@ struct RastaByteArray {
  * Frees the bytes array and sets length to 0
  * @param data the byte array
  */
-void freeRastaByteArray(struct RastaByteArray* data);
+void freeRastaByteArray(struct RastaByteArray *data);
 
 /**
  * Allocates space for the bytearray
  * @param data the data
  * @param length the length
  */
-void allocateRastaByteArray(struct RastaByteArray* data, unsigned int length);
+void allocateRastaByteArray(struct RastaByteArray *data, unsigned int length);
 
 /**
  * this will generate a 4 byte timestamp of the current system time
@@ -38,7 +42,7 @@ int isBigEndian();
  * @param v the uchar array
  * @param result the assigned uchar array; length should be 4
  */
-void hostLongToLe(uint32_t v, unsigned char* result);
+void hostLongToLe(uint32_t v, unsigned char *result);
 
 /**
  * Converts 4 little-endian bytes to a host ulong


### PR DESCRIPTION
This fixes problems occuring on 32-bit systems (like the RevPi), where handshake or connection timeouts occur directly instead of after a certain time. This is because the current time as well as the event intervals were not computed correctly (using multiplication with `unsigned long`s, which are 32 bit instead of 64 bit on 32-bit systems, causing overflows). 

This PR replaces all `unsigned long`s in time calculations by `unsigned long long`, which eliminates these problems. Also, we use already available constants for such multiplications more consistently.