### PR TITLE
Add Valgrind support and fix memory problems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
     - name: Install libopaque dependencies
       run: sudo apt-get install libsodium-dev pkgconf
 
+    - name: Install valgrind
+      run: sudo apt-get install valgrind
+
     - name: Install gRPC
       run: |
         sudo apt-get install build-essential autoconf libtool
@@ -74,6 +77,9 @@ jobs:
 
     - name: CTest
       run: cd ${{github.workspace}}/build && ctest . --output-on-failure
+
+    - name: Valgrind Memcheck
+      run: cd ${{github.workspace}}/build && ctest . -T memcheck --output-on-failure
 
     - name: Configure CMake without extensions
       # force full rebuild

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,8 @@ if(ENABLE_STATIC_ANALYSIS)
     set(CMAKE_C_CPPCHECK "cppcheck" "--enable=performance,information")
 endif(ENABLE_STATIC_ANALYSIS)
 
-set(VALGRIND_COMMAND_OPTIONS "--leak-check=full --show-leak-kinds=all")
+find_program(MEMORYCHECK_COMMAND valgrind)
+set(MEMORYCHECK_COMMAND_OPTIONS "--leak-check=full --show-leak-kinds=all")
 
 include(CTest)
 include(GNUInstallDirs)

--- a/examples/common/c/configfile.c
+++ b/examples/common/c/configfile.c
@@ -985,4 +985,6 @@ void load_configfile(rasta_config_info *c, struct logger_t *logger, const char *
     }
 
     c->initial_sequence_number = get_initial_seq_num(&config);
+
+    dictionary_free(&config.dictionary);
 }

--- a/examples/rcat/c/dtls.c
+++ b/examples/rcat/c/dtls.c
@@ -30,6 +30,9 @@ void prepare_certs(const char *config_path) {
 
         printf("Generated Certificates");
     }
+
+    dictionary_free(&config.dictionary);
+    rfree(config.values.redundancy.connections.data);
 }
 
 void printHelpAndExit(void) {
@@ -82,6 +85,8 @@ int main(int argc, char *argv[]) {
     fd_event input_available_event;
     struct connect_event_data input_available_event_data;
 
+    memset(&input_available_event, 0, sizeof(fd_event));
+
     input_available_event.callback = send_input_data;
     input_available_event.carry_data = &input_available_event_data;
     input_available_event.fd = STDIN_FILENO;
@@ -104,8 +109,7 @@ int main(int argc, char *argv[]) {
             .config = &config,
             .rasta_id = ID_S,
             .transport_sockets = toServer,
-            .transport_sockets_count = sizeof(toServer) / sizeof(toServer[0])
-        };
+            .transport_sockets_count = sizeof(toServer) / sizeof(toServer[0])};
 
         rasta_lib_init_configuration(rc, &config, &logger, &connection, 1);
 
@@ -148,8 +152,7 @@ int main(int argc, char *argv[]) {
             .config = &config,
             .rasta_id = ID_R,
             .transport_sockets = toServer,
-            .transport_sockets_count = sizeof(toServer) / sizeof(toServer[0])
-        };
+            .transport_sockets_count = sizeof(toServer) / sizeof(toServer[0])};
 
         rasta_lib_init_configuration(rc, &config, &logger, &connection, 1);
 

--- a/examples/rcat/c/kex.c
+++ b/examples/rcat/c/kex.c
@@ -84,6 +84,8 @@ int main(int argc, char *argv[]) {
     fd_event input_available_event;
     struct connect_event_data input_available_event_data;
 
+    memset(&input_available_event, 0, sizeof(fd_event));
+
     input_available_event.callback = send_input_data;
     input_available_event.carry_data = &input_available_event_data;
     input_available_event.fd = STDIN_FILENO;
@@ -105,8 +107,7 @@ int main(int argc, char *argv[]) {
             .config = &config,
             .rasta_id = ID_S,
             .transport_sockets = toServer,
-            .transport_sockets_count = sizeof(toServer) / sizeof(toServer[0])
-        };
+            .transport_sockets_count = sizeof(toServer) / sizeof(toServer[0])};
 
         rasta_lib_init_configuration(rc, &config, &logger, &connection, 1);
 
@@ -153,8 +154,7 @@ int main(int argc, char *argv[]) {
             .config = &config,
             .rasta_id = ID_R,
             .transport_sockets = toServer,
-            .transport_sockets_count = sizeof(toServer) / sizeof(toServer[0])
-        };
+            .transport_sockets_count = sizeof(toServer) / sizeof(toServer[0])};
 
         rasta_lib_init_configuration(rc, &config, &logger, &connection, 1);
 

--- a/examples/rcat/c/rcat.c
+++ b/examples/rcat/c/rcat.c
@@ -80,6 +80,8 @@ int main(int argc, char *argv[]) {
     fd_event input_available_event;
     struct connect_event_data input_available_event_data;
 
+    memset(&input_available_event, 0, sizeof(fd_event));
+
     input_available_event.callback = send_input_data;
     input_available_event.carry_data = &input_available_event_data;
     input_available_event.fd = STDIN_FILENO;
@@ -101,8 +103,7 @@ int main(int argc, char *argv[]) {
             .config = &config,
             .rasta_id = ID_S,
             .transport_sockets = toServer,
-            .transport_sockets_count = sizeof(toServer) / sizeof(toServer[0])
-        };
+            .transport_sockets_count = sizeof(toServer) / sizeof(toServer[0])};
 
         rasta_lib_init_configuration(rc, &config, &logger, &connection, 1);
 
@@ -145,8 +146,7 @@ int main(int argc, char *argv[]) {
             .config = &config,
             .rasta_id = ID_R,
             .transport_sockets = toServer,
-            .transport_sockets_count = sizeof(toServer) / sizeof(toServer[0])
-        };
+            .transport_sockets_count = sizeof(toServer) / sizeof(toServer[0])};
 
         rasta_lib_init_configuration(rc, &config, &logger, &connection, 1);
 

--- a/examples/rcat/c/tls.c
+++ b/examples/rcat/c/tls.c
@@ -30,6 +30,9 @@ void prepare_certs(const char *config_path) {
 
         printf("Generated Certificates");
     }
+
+    dictionary_free(&config.dictionary);
+    rfree(config.values.redundancy.connections.data);
 }
 
 void printHelpAndExit(void) {
@@ -92,6 +95,8 @@ int main(int argc, char *argv[]) {
     fd_event input_available_event;
     struct connect_event_data input_available_event_data;
 
+    memset(&input_available_event, 0, sizeof(fd_event));
+
     input_available_event.callback = send_input_data;
     input_available_event.carry_data = &input_available_event_data;
     input_available_event.fd = STDIN_FILENO;
@@ -114,8 +119,7 @@ int main(int argc, char *argv[]) {
             .config = &config,
             .rasta_id = ID_S,
             .transport_sockets = toServer,
-            .transport_sockets_count = 2
-        };
+            .transport_sockets_count = 2};
 
         rasta_lib_init_configuration(rc, &config, &logger, &connection, 1);
 
@@ -158,8 +162,7 @@ int main(int argc, char *argv[]) {
             .config = &config,
             .rasta_id = ID_R,
             .transport_sockets = toServer,
-            .transport_sockets_count = 2
-        };
+            .transport_sockets_count = 2};
 
         rasta_lib_init_configuration(rc, &config, &logger, &connection, 1);
 

--- a/examples/sci/common/sci.c
+++ b/examples/sci/common/sci.c
@@ -60,13 +60,13 @@ sci_telegram *sci_decode_telegram(struct RastaByteArray data) {
         return NULL;
     }
 
-    sci_telegram *telegram = rmalloc(sizeof(sci_telegram));
-
     // check if a valid protocol was provided
     if (!(data.bytes[0] == SCI_PROTOCOL_P || data.bytes[0] == SCI_PROTOCOL_LS)) {
         // invalid protocol
         return NULL;
     }
+
+    sci_telegram *telegram = rmalloc(sizeof(sci_telegram));
 
     // copy the basic data into the telegram
     telegram->protocol_type = data.bytes[0];

--- a/examples/sci/scitest/c/sciTests.c
+++ b/examples/sci/scitest/c/sciTests.c
@@ -36,6 +36,7 @@ void testEncode() {
     CU_ASSERT_NSTRING_EQUAL(expected_telegram, res.bytes, res.length);
 
     rfree(telegram);
+    freeRastaByteArray(&res);
 }
 
 void testDecode() {
@@ -84,6 +85,8 @@ void testDecodeInvalid() {
 
     CU_ASSERT_PTR_NULL(sci_decode_telegram(data));
 
+    freeRastaByteArray(&data);
+
     unsigned char telegram_bytes2[] = {
         0x30};
 
@@ -91,6 +94,8 @@ void testDecodeInvalid() {
     rmemcpy(data.bytes, telegram_bytes2, 1);
 
     CU_ASSERT_PTR_NULL(sci_decode_telegram(data));
+
+    freeRastaByteArray(&data);
 
     unsigned char telegram_bytes3[129] = {0};
     allocateRastaByteArray(&data, 129);
@@ -251,6 +256,8 @@ void testParseVersionRequest() {
     sci_set_message_type(telegram, SCI_MESSAGE_TYPE_VERSION_RESPONSE);
     result = sci_parse_version_request_payload(telegram, &version);
     CU_ASSERT_EQUAL(result, SCI_PARSE_INVALID_MESSAGE_TYPE);
+
+    rfree(telegram);
 }
 
 void testParseVersionResponse() {
@@ -281,4 +288,6 @@ void testParseVersionResponse() {
     sci_set_message_type(telegram, SCI_MESSAGE_TYPE_VERSION_REQUEST);
     result = sci_parse_version_response_payload(telegram, &version, &version_check_result, &len, &checksum[0]);
     CU_ASSERT_EQUAL(result, SCI_PARSE_INVALID_MESSAGE_TYPE);
+
+    rfree(telegram);
 }

--- a/examples/sci/scitest/c/scipTests.c
+++ b/examples/sci/scitest/c/scipTests.c
@@ -67,6 +67,8 @@ void testParseChangeLocation() {
     sci_set_message_type(telegram, SCIP_MESSAGE_TYPE_TIMEOUT);
     result = scip_parse_change_location_payload(telegram, &location);
     CU_ASSERT_EQUAL(result, SCI_PARSE_INVALID_MESSAGE_TYPE);
+
+    rfree(telegram);
 }
 
 void testParseLocationStatus() {
@@ -81,4 +83,6 @@ void testParseLocationStatus() {
     sci_set_message_type(telegram, SCIP_MESSAGE_TYPE_TIMEOUT);
     result = scip_parse_location_status_payload(telegram, &location);
     CU_ASSERT_EQUAL(result, SCI_PARSE_INVALID_MESSAGE_TYPE);
+
+    rfree(telegram);
 }

--- a/src/c/rasta.c
+++ b/src/c/rasta.c
@@ -108,6 +108,11 @@ void rasta_disconnect(struct rasta_connection *connection) {
 void rasta_cleanup(rasta_lib_configuration_t user_configuration) {
     sr_cleanup(&user_configuration->h);
     for (unsigned i = 0; i < user_configuration->h.rasta_connections_length; i++) {
+        struct RastaByteArray *elem;
+        while ((elem = fifo_pop(user_configuration->h.rasta_connections[i].fifo_retransmission))) {
+            freeRastaByteArray(elem);
+            rfree(elem);
+        }
         fifo_destroy(&user_configuration->h.rasta_connections[i].fifo_retransmission);
         fifo_destroy(&user_configuration->h.rasta_connections[i].fifo_send);
         fifo_destroy(&user_configuration->h.rasta_connections[i].fifo_receive);

--- a/src/c/rasta.c
+++ b/src/c/rasta.c
@@ -37,7 +37,7 @@ void rasta_listen(rasta_lib_configuration_t user_configuration) {
     sr_listen(&user_configuration->h);
 }
 
-struct rasta_connection * rasta_accept(rasta_lib_configuration_t user_configuration) {
+struct rasta_connection *rasta_accept(rasta_lib_configuration_t user_configuration) {
     struct rasta_handle *h = &user_configuration->h;
     event_system *event_system = &user_configuration->rasta_lib_event_system;
 
@@ -56,7 +56,7 @@ struct rasta_connection * rasta_accept(rasta_lib_configuration_t user_configurat
     return NULL;
 }
 
-struct rasta_connection* rasta_connect(rasta_lib_configuration_t user_configuration, unsigned long id) {
+struct rasta_connection *rasta_connect(rasta_lib_configuration_t user_configuration, unsigned long id) {
     return sr_connect(&user_configuration->h, id);
 }
 
@@ -80,7 +80,7 @@ int rasta_recv(rasta_lib_configuration_t user_configuration, struct rasta_connec
 
     if (len < elem->length) {
         logger_log(connection->logger, LOG_LEVEL_INFO, "RaSTA receive",
-            "supplied buffer (%zd bytes) is smaller than message length (%d bytes) - received message may be incomplete!", len, elem->length);
+                   "supplied buffer (%zd bytes) is smaller than message length (%d bytes) - received message may be incomplete!", len, elem->length);
     }
 
     rmemcpy(buf, elem->bytes, received_len);
@@ -110,7 +110,9 @@ void rasta_cleanup(rasta_lib_configuration_t user_configuration) {
     for (unsigned i = 0; i < user_configuration->h.rasta_connections_length; i++) {
         fifo_destroy(&user_configuration->h.rasta_connections[i].fifo_retransmission);
         fifo_destroy(&user_configuration->h.rasta_connections[i].fifo_send);
+        fifo_destroy(&user_configuration->h.rasta_connections[i].fifo_receive);
     }
     rfree(user_configuration->h.rasta_connections);
-
+    rfree(user_configuration->h.config->redundancy.connections.data);
+    rfree(user_configuration->h.config->accepted_versions);
 }

--- a/src/c/redundancy/rasta_red_multiplexer.c
+++ b/src/c/redundancy/rasta_red_multiplexer.c
@@ -90,6 +90,8 @@ int receive_packet(redundancy_mux *mux, rasta_transport_channel *transport_chann
         if (deferqueue_isfull(&channel->defer_q)) {
             // Discard incoming packet
             logger_log(channel->logger, LOG_LEVEL_INFO, "RaSTA Red receive", "discarding packet because defer queue is full");
+            freeRastaByteArray(&receivedPacket.data.data);
+            freeRastaByteArray(&receivedPacket.data.checksum);
         } else {
             // If this turned out to be a new connection or new application data, break from processing
             result |= red_f_receiveData(channel, receivedPacket, transport_channel->id);
@@ -248,8 +250,6 @@ bool redundancy_mux_bind(struct rasta_handle *h) {
 }
 
 void redundancy_mux_close(redundancy_mux *mux) {
-    // TODO: red_f_cleanup should be called when closing a rasta_connection
-
     // Close listening ports
     for (unsigned int i = 0; i < mux->port_count; ++i) {
         logger_log(mux->logger, LOG_LEVEL_DEBUG, "RaSTA RedMux close", "closing socket %d/%d", i + 1, mux->port_count);
@@ -259,9 +259,7 @@ void redundancy_mux_close(redundancy_mux *mux) {
     mux->port_count = 0;
     rfree(mux->transport_sockets);
     for (unsigned int i = 0; i < mux->redundancy_channels_count; i++) {
-        rfree(mux->redundancy_channels[i].transport_channels);
-        freeRastaByteArray(&mux->redundancy_channels[i].hashing_context.key);
-        deferqueue_destroy(&mux->redundancy_channels[i].defer_q);
+        red_f_cleanup(&mux->redundancy_channels[i]);
     }
     rfree(mux->redundancy_channels);
     rfree(mux->listen_ports);

--- a/src/c/redundancy/rasta_red_multiplexer.c
+++ b/src/c/redundancy/rasta_red_multiplexer.c
@@ -260,8 +260,11 @@ void redundancy_mux_close(redundancy_mux *mux) {
     rfree(mux->transport_sockets);
     for (unsigned int i = 0; i < mux->redundancy_channels_count; i++) {
         rfree(mux->redundancy_channels[i].transport_channels);
+        freeRastaByteArray(&mux->redundancy_channels[i].hashing_context.key);
+        deferqueue_destroy(&mux->redundancy_channels[i].defer_q);
     }
     rfree(mux->redundancy_channels);
+    rfree(mux->listen_ports);
 
     freeRastaByteArray(&mux->sr_hashing_context.key);
 }

--- a/src/c/redundancy/rastaredundancy.c
+++ b/src/c/redundancy/rastaredundancy.c
@@ -5,9 +5,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <rasta/rastahandle.h>
 #include <rasta/rastautil.h>
 #include <rasta/rmemory.h>
-#include <rasta/rastahandle.h>
 
 #include "../retransmission/safety_retransmission.h"
 #include "../transport/transport.h"
@@ -91,6 +91,9 @@ int red_f_deliverDeferQueue(rasta_connection *con, rasta_redundancy_channel *cha
         // remove message from queue (effectively a pop operation with the get call)
         deferqueue_remove(&channel->defer_q, channel->seq_rx);
         logger_log(channel->logger, LOG_LEVEL_DEBUG, "RaSTA Red deliver deferq", "remove message from deferq");
+
+        freeRastaByteArray(&queuePacket.data.data);
+        freeRastaByteArray(&queuePacket.data.checksum);
 
         // increase seq_rx
         channel->seq_rx++;
@@ -239,17 +242,17 @@ void red_f_deferTmo(rasta_connection *h, rasta_redundancy_channel *channel) {
 }
 
 void red_f_cleanup(rasta_redundancy_channel *channel) {
-    // destroy the defer queue
-    // deferqueue_destroy(&channel->defer_q);
-
     // destroy the diagnostics buffer
-    // deferqueue_destroy(&channel->diagnostics_packet_buffer);
+    deferqueue_destroy(&channel->diagnostics_packet_buffer);
+
+    // destroy the defer queue
+    deferqueue_destroy(&channel->defer_q);
 
     // free the channels
-    // rfree(channel->transport_channels);
-    // channel->transport_channel_count = 0;
+    rfree(channel->transport_channels);
+    channel->transport_channel_count = 0;
 
-    // freeRastaByteArray(&channel->hashing_context.key);
+    freeRastaByteArray(&channel->hashing_context.key);
 
     logger_log(channel->logger, LOG_LEVEL_DEBUG, "RaSTA Red cleanup", "Cleanup complete");
 }

--- a/src/c/retransmission/safety_retransmission.c
+++ b/src/c/retransmission/safety_retransmission.c
@@ -75,6 +75,10 @@ void sr_add_app_messages_to_buffer(struct rasta_connection *con, struct RastaPac
         sr_update_timeout_interval(packet->confirmed_timestamp, con, &con->config->sending);
         sr_diagnostic_update(con, packet, &con->config->sending);
     }
+
+    freeRastaByteArray(&packet->data);
+    freeRastaByteArray(&packet->checksum);
+    freeRastaMessageData(&received_data);
 }
 
 void sr_remove_confirmed_messages(struct rasta_connection *con) {
@@ -88,6 +92,10 @@ void sr_remove_confirmed_messages(struct rasta_connection *con) {
         logger_log(con->logger, LOG_LEVEL_DEBUG, "RaSTA remove confirmed", "removing packet with sn = %lu",
                    (long unsigned int)packet.sequence_number);
 
+        freeRastaByteArray(elem);
+        freeRastaByteArray(&packet.data);
+        rfree(elem);
+
         // message is confirmed when CS_R - SN_PDU >= 0
         // equivalent to SN_PDU <= CS_R
         if (packet.sequence_number == con->cs_r) {
@@ -95,17 +103,8 @@ void sr_remove_confirmed_messages(struct rasta_connection *con) {
             // SN_PDU will be bigger than CS_R (because of FIFO property of mqueue)
             // that means we removed all confirmed messages and have to leave the loop to stop removing packets
             logger_log(con->logger, LOG_LEVEL_DEBUG, "RaSTA remove confirmed", "last confirmed packet removed");
-
-            freeRastaByteArray(elem);
-            freeRastaByteArray(&packet.data);
-            rfree(elem);
-
             break;
         }
-
-        freeRastaByteArray(elem);
-        freeRastaByteArray(&packet.data);
-        rfree(elem);
     }
 
     // sending is now possible again (space in the retransmission queue is available), so we should trigger it

--- a/src/c/retransmission/safety_retransmission.c
+++ b/src/c/retransmission/safety_retransmission.c
@@ -344,6 +344,10 @@ void sr_retransmit_data(rasta_connection *connection) {
         freeRastaByteArray(&packets[i]);
         freeRastaByteArray(&new_p);
         freeRastaByteArray(&old_p.data);
+        freeRastaByteArray(&old_p.checksum);
+        freeRastaByteArray(&data.data);
+
+        freeRastaMessageData(&app_messages);
     }
 
     // close retransmission with heartbeat

--- a/src/c/transport/ssl_utils.c
+++ b/src/c/transport/ssl_utils.c
@@ -280,5 +280,8 @@ void tls_pin_certificate(WOLFSSL *ssl, const char *peer_tls_cert_path) {
             logger_hexdump(&sha_logger, LOG_LEVEL_DEBUG, pinned_digest_buffer, pinned_digest_buffer_size, "Pinned certificate (digest)");
             abort();
         }
+
+        wolfSSL_X509_free(pinned_cert);
+        wolfSSL_X509_free(peer_cert);
     }
 }

--- a/src/c/util/rastamodule.c
+++ b/src/c/util/rastamodule.c
@@ -237,6 +237,7 @@ struct RastaByteArray rastaRedundancyPacketToBytes(struct RastaRedundancyPacket 
     rmemcpy(&result.bytes[8 + internal_packet_len], checksum_storage, (packet->checksum_type.width / 8));
 
     // free the temporary checksum data
+    freeRastaByteArray(&internal_packet_bytes);
     freeRastaByteArray(&temp_wo_checksum);
 
     return result;

--- a/src/c/util/rastautil.c
+++ b/src/c/util/rastautil.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <string.h>
 #include <time.h>
 
 #include <rasta/rastautil.h>
@@ -36,6 +37,7 @@ void freeRastaByteArray(struct RastaByteArray *data) {
 
 void allocateRastaByteArray(struct RastaByteArray *data, unsigned int length) {
     data->bytes = rmalloc(length);
+    memset(data->bytes, 0, length);
     data->length = length;
 }
 

--- a/test/rasta_test/c/config_test.c
+++ b/test/rasta_test/c/config_test.c
@@ -8,6 +8,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <rasta/rmemory.h>
+
 void check_std_config() {
     // remove old file
     remove("config.cfg");
@@ -52,6 +54,8 @@ void check_std_config() {
     // cechk general
     CU_ASSERT_EQUAL(cfg.values.general.rasta_network, 0);
     CU_ASSERT_EQUAL(cfg.values.general.rasta_id, 0);
+
+    dictionary_free(&cfg.dictionary);
 }
 
 void check_var_config() {
@@ -152,4 +156,7 @@ void check_var_config() {
     entr = config_get(&cfg, "HEX");
     CU_ASSERT_EQUAL(entr.type, DICTIONARY_NUMBER);
     CU_ASSERT_EQUAL(entr.value.number, 0xff32);
+
+    dictionary_free(&cfg.dictionary);
+    rfree(cfg.values.redundancy.connections.data);
 }

--- a/test/rasta_test/c/fifo_test.c
+++ b/test/rasta_test/c/fifo_test.c
@@ -46,6 +46,7 @@ void test_push() {
     CU_ASSERT_EQUAL(fifo_get_size(fifo), 3);
 
     fifo_destroy(&fifo);
+    freeRastaByteArray(&elem);
     rfree(test_str);
     rfree(struct_elem);
 }

--- a/test/rasta_test/c/rastacrc_test.c
+++ b/test/rasta_test/c/rastacrc_test.c
@@ -1,5 +1,5 @@
-#include <rasta/rastacrc.h>
 #include <CUnit/Basic.h>
+#include <rasta/rastacrc.h>
 
 #define TEST_VAL "123456789"
 

--- a/test/rasta_test/c/rastadeferqueue_test.c
+++ b/test/rasta_test/c/rastadeferqueue_test.c
@@ -1,12 +1,15 @@
 #include "../headers/rastadeferqueue_test.h"
-#include <rasta/rastadeferqueue.h>
 #include <CUnit/Basic.h>
+#include <rasta/rastadeferqueue.h>
+#include <rasta/rmemory.h>
 
 void test_deferqueue_init() {
     struct defer_queue queue_to_test = deferqueue_init(3);
 
     CU_ASSERT_EQUAL(queue_to_test.max_count, 3);
     CU_ASSERT_EQUAL(queue_to_test.count, 0);
+
+    deferqueue_destroy(&queue_to_test);
 }
 
 void test_deferqueue_destroy() {
@@ -42,6 +45,8 @@ void test_deferqueue_add() {
     CU_ASSERT_EQUAL(queue_to_test.elements[1].packet.sequence_number, 2);
     CU_ASSERT_EQUAL(queue_to_test.elements[0].received_timestamp, packet_ts);
     CU_ASSERT_EQUAL(queue_to_test.elements[1].received_timestamp, packet2_ts);
+
+    deferqueue_destroy(&queue_to_test);
 }
 
 void test_deferqueue_remove() {
@@ -67,6 +72,8 @@ void test_deferqueue_remove() {
     deferqueue_remove(&queue_to_test, 2);
 
     CU_ASSERT_EQUAL(queue_to_test.count, 0);
+
+    deferqueue_destroy(&queue_to_test);
 }
 
 void test_deferqueue_add_full() {
@@ -86,6 +93,8 @@ void test_deferqueue_add_full() {
     CU_ASSERT_EQUAL(queue_to_test.count, 1);
     CU_ASSERT_EQUAL(queue_to_test.elements[0].packet.sequence_number, 1);
     CU_ASSERT_EQUAL(queue_to_test.elements[0].received_timestamp, packet_ts);
+
+    deferqueue_destroy(&queue_to_test);
 }
 
 void test_deferqueue_remove_not_in_queue() {
@@ -109,6 +118,8 @@ void test_deferqueue_remove_not_in_queue() {
     CU_ASSERT_EQUAL(queue_to_test.elements[1].packet.sequence_number, 2);
     CU_ASSERT_EQUAL(queue_to_test.elements[0].received_timestamp, packet_ts);
     CU_ASSERT_EQUAL(queue_to_test.elements[1].received_timestamp, packet2_ts);
+
+    deferqueue_destroy(&queue_to_test);
 }
 
 void test_deferqueue_contains() {
@@ -133,6 +144,8 @@ void test_deferqueue_contains() {
 
     res = deferqueue_contains(&queue_to_test, 3);
     CU_ASSERT_EQUAL(res, 0);
+
+    deferqueue_destroy(&queue_to_test);
 }
 
 void test_deferqueue_isfull() {
@@ -158,6 +171,8 @@ void test_deferqueue_isfull() {
 
     res = deferqueue_isfull(&queue_to_test);
     CU_ASSERT_EQUAL(res, 1);
+
+    deferqueue_destroy(&queue_to_test);
 }
 
 void test_deferqueue_smallestseqnr() {
@@ -179,6 +194,8 @@ void test_deferqueue_smallestseqnr() {
     int res = deferqueue_smallest_seqnr(&queue_to_test);
 
     CU_ASSERT_EQUAL(res, 1);
+
+    deferqueue_destroy(&queue_to_test);
 }
 
 void test_deferqueue_get() {
@@ -203,6 +220,8 @@ void test_deferqueue_get() {
     // not in queue, struct should be completely 0s
     res = deferqueue_get(&queue_to_test, 42);
     CU_ASSERT_EQUAL(res.sequence_number, 0);
+
+    deferqueue_destroy(&queue_to_test);
 }
 
 void test_deferqueue_sorted() {
@@ -233,6 +252,8 @@ void test_deferqueue_sorted() {
 
     CU_ASSERT_EQUAL(queue_to_test.elements[0].received_timestamp, 2);
     CU_ASSERT_EQUAL(queue_to_test.elements[1].received_timestamp, 3);
+
+    deferqueue_destroy(&queue_to_test);
 }
 
 void test_deferqueue_clear() {
@@ -252,6 +273,8 @@ void test_deferqueue_clear() {
     deferqueue_clear(&queue_to_test);
 
     CU_ASSERT_EQUAL(queue_to_test.count, 0);
+
+    deferqueue_destroy(&queue_to_test);
 }
 
 void test_deferqueue_get_ts() {
@@ -270,6 +293,8 @@ void test_deferqueue_get_ts() {
 
     CU_ASSERT_EQUAL(deferqueue_get_ts(&queue_to_test, 3), ts_1);
     CU_ASSERT_EQUAL(deferqueue_get_ts(&queue_to_test, 1), ts_2);
+
+    deferqueue_destroy(&queue_to_test);
 }
 
 void test_deferqueue_get_ts_doesnt_contain() {
@@ -287,4 +312,6 @@ void test_deferqueue_get_ts_doesnt_contain() {
     deferqueue_add(&queue_to_test, packet2, ts_2);
 
     CU_ASSERT_EQUAL(deferqueue_get_ts(&queue_to_test, 8), 0);
+
+    deferqueue_destroy(&queue_to_test);
 }

--- a/test/rasta_test/c/rastafactory_test.c
+++ b/test/rasta_test/c/rastafactory_test.c
@@ -1,6 +1,7 @@
 #include "../headers/rastafactory_test.h"
 #include "CUnit/Basic.h"
 #include <rasta/rastafactory.h>
+#include <rasta/rmemory.h>
 
 void checkConnectionPacket() {
     rasta_hashing_context_t context;
@@ -35,6 +36,8 @@ void checkConnectionPacket() {
             CU_ASSERT_EQUAL(con.version[i], i);
         }
 
+        freeRastaByteArray(&r.data);
+
         r = createConnectionResponse(1, 2, 3, 4, 5, 6, 7, ver, &context);
 
         // check standart values
@@ -57,7 +60,11 @@ void checkConnectionPacket() {
         r.data.length -= 1;
         con = extractRastaConnectionData(&r);
         CU_ASSERT_EQUAL(getRastafactoryLastError(), RASTA_ERRORS_WRONG_PACKAGE_FORMAT);
+
+        freeRastaByteArray(&r.data);
     }
+
+    freeRastaByteArray(&context.key);
 }
 
 void checkNormalPacket() {
@@ -103,6 +110,8 @@ void checkNormalPacket() {
         CU_ASSERT_EQUAL(r.confirmed_timestamp, 6);
         CU_ASSERT_EQUAL(r.type, RASTA_TYPE_HB);
     }
+
+    freeRastaByteArray(&hashing_context.key);
 }
 
 void checkDisconnectionRequest() {
@@ -136,7 +145,11 @@ void checkDisconnectionRequest() {
         r.data.length -= 1;
         data = extractRastaDisconnectionData(&r);
         CU_ASSERT_EQUAL(getRastafactoryLastError(), RASTA_ERRORS_WRONG_PACKAGE_FORMAT);
+
+        freeRastaByteArray(&r.data);
     }
+
+    freeRastaByteArray(&hashing_context.key);
 }
 
 void checkMessagePacket() {
@@ -191,6 +204,7 @@ void checkMessagePacket() {
         CU_ASSERT_EQUAL(m.data_array[1].bytes[1], 4);
 
         freeRastaMessageData(&m);
+        freeRastaByteArray(&r.data);
 
         // check retransmitted message data
         r = createRetransmittedDataMessage(1, 2, 3, 4, 5, 6, data, &hashing_context);
@@ -216,9 +230,11 @@ void checkMessagePacket() {
         CU_ASSERT_EQUAL(m.data_array[1].bytes[1], 4);
 
         freeRastaMessageData(&m);
+        freeRastaByteArray(&r.data);
     }
 
     freeRastaMessageData(&data);
+    freeRastaByteArray(&hashing_context.key);
 }
 
 void testCreateRedundancyPacket() {

--- a/test/rasta_test/c/rastamodule_test.c
+++ b/test/rasta_test/c/rastamodule_test.c
@@ -56,6 +56,8 @@ void testConversion() {
 
         // check if checksum is correct
         CU_ASSERT_EQUAL(s.checksum_correct, 1);
+        freeRastaByteArray(&s.data);
+        freeRastaByteArray(&s.checksum);
 
         // manipulate data
         data.bytes[8] = 0x43;
@@ -68,10 +70,19 @@ void testConversion() {
 
         // check data failure
         r.length = 2;
-        bytesToRastaPacket(rastaModuleToBytes(&r, &context), &context, &s);
+        struct RastaByteArray r_bytes = rastaModuleToBytes(&r, &context);
+        bytesToRastaPacket(r_bytes, &context, &s);
 
         CU_ASSERT_EQUAL(getRastamoduleLastError(), RASTA_ERRORS_PACKAGE_LENGTH_INVALID);
+
+        freeRastaByteArray(&s.data);
+        freeRastaByteArray(&s.checksum);
+        freeRastaByteArray(&r.data);
+        freeRastaByteArray(&data);
+        freeRastaByteArray(&r_bytes);
     }
+
+    freeRastaByteArray(&context.key);
 }
 
 void testRedundancyConversionWithCrcChecksumCorrect() {
@@ -131,6 +142,12 @@ void testRedundancyConversionWithCrcChecksumCorrect() {
 
     // check if internal packet checksum is correct
     CU_ASSERT_EQUAL(convertedFromBytes.data.checksum_correct, 1);
+
+    freeRastaByteArray(&r.data);
+    freeRastaByteArray(&convertedFromBytes.data.data);
+    freeRastaByteArray(&convertedFromBytes.data.checksum);
+    freeRastaByteArray(&convertedToBytes);
+    freeRastaByteArray(&context.key);
 }
 
 void testRedundancyConversionWithoutChecksum() {
@@ -189,6 +206,12 @@ void testRedundancyConversionWithoutChecksum() {
 
     // check if internal packet checksum is correct
     CU_ASSERT_EQUAL(convertedFromBytes.data.checksum_correct, 1);
+
+    freeRastaByteArray(&r.data);
+    freeRastaByteArray(&convertedFromBytes.data.data);
+    freeRastaByteArray(&convertedFromBytes.data.checksum);
+    freeRastaByteArray(&convertedToBytes);
+    freeRastaByteArray(&context.key);
 }
 
 void testRedundancyConversionIncorrectChecksum() {
@@ -229,4 +252,10 @@ void testRedundancyConversionIncorrectChecksum() {
 
     // check if internal packet checksum is incorrect
     CU_ASSERT_EQUAL(convertedFromBytes.data.checksum_correct, 0);
+
+    freeRastaByteArray(&r.data);
+    freeRastaByteArray(&convertedFromBytes.data.data);
+    freeRastaByteArray(&convertedFromBytes.data.checksum);
+    freeRastaByteArray(&convertedToBytes);
+    freeRastaByteArray(&context.key);
 }

--- a/test/rasta_test/c/safety_retransmission_test.c
+++ b/test/rasta_test/c/safety_retransmission_test.c
@@ -88,6 +88,9 @@ void test_sr_retransmit_data_shouldSendFinalHeartbeat() {
 
     fifo_destroy(&connection.fifo_retransmission);
 
+    freeRastaByteArray(hb_message);
+    rfree(hb_message);
+
     rfree(mux.transport_sockets);
     freeRastaByteArray(&fake_channel.hashing_context.key);
     freeRastaByteArray(&mux.sr_hashing_context.key);
@@ -192,6 +195,11 @@ void test_sr_retransmit_data_shouldRetransmitPackage() {
 
     fifo_destroy(&connection.fifo_retransmission);
     fifo_destroy(&test_send_fifo);
+
+    freeRastaByteArray(retrdata_message);
+    freeRastaByteArray(hb_message);
+    rfree(retrdata_message);
+    rfree(hb_message);
 
     rfree(mux.transport_sockets);
     freeRastaByteArray(&data.data);

--- a/test/rasta_test/c/safety_retransmission_test.c
+++ b/test/rasta_test/c/safety_retransmission_test.c
@@ -51,12 +51,17 @@ void test_sr_retransmit_data_shouldSendFinalHeartbeat() {
     rasta_redundancy_channel fake_channel;
     fake_channel.mux = &mux;
     fake_channel.associated_id = SERVER_ID;
+    fake_channel.hashing_context.algorithm = RASTA_ALGO_MD4;
     fake_channel.hashing_context.hash_length = RASTA_CHECKSUM_NONE;
+    fake_channel.seq_tx = 0;
     rasta_md4_set_key(&fake_channel.hashing_context, 0, 0, 0, 0);
 
     rasta_transport_channel transport;
     transport.send_callback = fake_send_callback;
     transport.connected = true;
+    transport.remote_port = 1234;
+    strncpy(transport.remote_ip_address, "127.0.0.1", 10);
+
     fake_channel.transport_channels = &transport;
     fake_channel.transport_channel_count = 1;
 
@@ -68,6 +73,7 @@ void test_sr_retransmit_data_shouldSendFinalHeartbeat() {
     connection.fifo_retransmission = fifo_init(0);
     connection.redundancy_channel = &fake_channel;
     connection.config = &info;
+    connection.logger = &logger;
 
     sr_retransmit_data(&connection);
 
@@ -81,6 +87,10 @@ void test_sr_retransmit_data_shouldSendFinalHeartbeat() {
     CU_ASSERT_EQUAL(RASTA_TYPE_HB, leShortToHost(hb_message->bytes + 8 + 2));
 
     fifo_destroy(&connection.fifo_retransmission);
+
+    rfree(mux.transport_sockets);
+    freeRastaByteArray(&fake_channel.hashing_context.key);
+    freeRastaByteArray(&mux.sr_hashing_context.key);
 }
 
 void test_sr_retransmit_data_shouldRetransmitPackage() {
@@ -111,12 +121,17 @@ void test_sr_retransmit_data_shouldRetransmitPackage() {
     rasta_redundancy_channel fake_channel;
     fake_channel.mux = &mux;
     fake_channel.associated_id = SERVER_ID;
+    fake_channel.hashing_context.algorithm = RASTA_ALGO_MD4;
     fake_channel.hashing_context.hash_length = RASTA_CHECKSUM_NONE;
+    fake_channel.seq_tx = 0;
     rasta_md4_set_key(&fake_channel.hashing_context, 0, 0, 0, 0);
 
     rasta_transport_channel transport;
     transport.send_callback = fake_send_callback;
     transport.connected = true;
+    transport.remote_port = 1234;
+    strncpy(transport.remote_ip_address, "127.0.0.1", 10);
+
     fake_channel.transport_channels = &transport;
     fake_channel.transport_channel_count = 1;
 
@@ -128,6 +143,7 @@ void test_sr_retransmit_data_shouldRetransmitPackage() {
     connection.fifo_retransmission = fifo_init(1);
     connection.redundancy_channel = &fake_channel;
     connection.config = &info;
+    connection.logger = &logger;
 
     struct RastaMessageData app_messages;
     struct RastaByteArray message;
@@ -137,6 +153,7 @@ void test_sr_retransmit_data_shouldRetransmitPackage() {
     app_messages.data_array = &message;
 
     rasta_hashing_context_t hashing_context;
+    hashing_context.algorithm = RASTA_ALGO_MD4;
     hashing_context.hash_length = RASTA_CHECKSUM_NONE;
     rasta_md4_set_key(&hashing_context, 0, 0, 0, 0);
     h.hashing_context = &hashing_context;
@@ -147,6 +164,7 @@ void test_sr_retransmit_data_shouldRetransmitPackage() {
     allocateRastaByteArray(to_fifo, packet.length);
     rmemcpy(to_fifo->bytes, packet.bytes, packet.length);
     fifo_push(connection.fifo_retransmission, to_fifo);
+    freeRastaByteArray(&packet);
 
     // Act
     sr_retransmit_data(&connection);
@@ -173,4 +191,11 @@ void test_sr_retransmit_data_shouldRetransmitPackage() {
     CU_ASSERT_EQUAL(RASTA_TYPE_HB, leShortToHost(hb_message->bytes + 8 + 2));
 
     fifo_destroy(&connection.fifo_retransmission);
+    fifo_destroy(&test_send_fifo);
+
+    rfree(mux.transport_sockets);
+    freeRastaByteArray(&data.data);
+    freeRastaByteArray(&hashing_context.key);
+    freeRastaByteArray(&fake_channel.hashing_context.key);
+    freeRastaByteArray(&mux.sr_hashing_context.key);
 }

--- a/test/rasta_transport_test/c/transport_test.c
+++ b/test/rasta_transport_test/c/transport_test.c
@@ -36,7 +36,7 @@ void test_transport_init_should_initialize_receive_event() {
     rasta_config_tls tls_config = {0};
 
     // Act
-    transport_init(&h, &channel, 100, "127.0.0.1", 4711, &tls_config);
+    transport_init(&h, &channel, 0, "127.0.0.1", 4711, &tls_config);
 
     // Assert
 
@@ -57,7 +57,7 @@ void test_transport_init_should_initialize_receive_event_data() {
     rasta_config_tls tls_config = {0};
 
     // Act
-    transport_init(&h, &channel, 100, "127.0.0.1", 4711, &tls_config);
+    transport_init(&h, &channel, 0, "127.0.0.1", 4711, &tls_config);
 
     // Assert
 
@@ -79,7 +79,7 @@ void test_transport_init_should_add_receive_event_to_event_system() {
     rasta_config_tls tls_config = {0};
 
     // Act
-    transport_init(&h, &channel, 100, "127.0.0.1", 4711, &tls_config);
+    transport_init(&h, &channel, 0, "127.0.0.1", 4711, &tls_config);
 
     // Assert
 
@@ -115,7 +115,7 @@ void test_transport_create_socket_should_create_fd() {
     rasta_config_tls tls_config = {0};
 
     // Act
-    transport_create_socket(&h, &socket, 42, &tls_config);
+    transport_create_socket(&h, &socket, 0, &tls_config);
 
     // Assert
     CU_ASSERT(socket.file_descriptor >= 0);
@@ -137,8 +137,8 @@ void test_transport_connect_should_set_connected() {
         .key_path = "../examples/server.key",
     };
 
-    transport_init(&h, &channel, 100, "127.0.0.1", 4711, &tls_config);
-    transport_create_socket(&h, &socket, 42, &tls_config);
+    transport_init(&h, &channel, 0, "127.0.0.1", 4711, &tls_config);
+    transport_create_socket(&h, &socket, 0, &tls_config);
 
     // Assert
     CU_ASSERT_FALSE(channel.connected);
@@ -166,8 +166,8 @@ void test_transport_connect_should_set_equal_fds() {
         .key_path = "../examples/server.key",
     };
 
-    transport_init(&h, &channel, 100, "127.0.0.1", 4711, &tls_config);
-    transport_create_socket(&h, &socket, 42, &tls_config);
+    transport_init(&h, &channel, 0, "127.0.0.1", 4711, &tls_config);
+    transport_create_socket(&h, &socket, 0, &tls_config);
 
     // Act
     CU_ASSERT_EQUAL(transport_connect(&socket, &channel), 0);

--- a/test/rasta_transport_test/c/transport_test_tcp.c
+++ b/test/rasta_transport_test/c/transport_test_tcp.c
@@ -17,10 +17,10 @@ void test_transport_create_socket_should_initialize_accept_event() {
     rasta_transport_channel channel = {0};
     rasta_config_tls tls_config = {0};
 
-    transport_init(&h, &channel, 100, "127.0.0.1", 4711, &tls_config);
+    transport_init(&h, &channel, 0, "127.0.0.1", 4711, &tls_config);
 
     // Act
-    transport_create_socket(&h, &socket, 42, &tls_config);
+    transport_create_socket(&h, &socket, 0, &tls_config);
 
     // Assert
     CU_ASSERT_PTR_EQUAL(socket.accept_event.callback, channel_accept_event);
@@ -39,10 +39,10 @@ void test_transport_create_socket_should_initialize_accept_event_data() {
     rasta_transport_channel channel = {0};
     rasta_config_tls tls_config = {0};
 
-    transport_init(&h, &channel, 100, "127.0.0.1", 4711, &tls_config);
+    transport_init(&h, &channel, 0, "127.0.0.1", 4711, &tls_config);
 
     // Act
-    transport_create_socket(&h, &socket, 42, &tls_config);
+    transport_create_socket(&h, &socket, 0, &tls_config);
 
     // Assert
     CU_ASSERT_PTR_EQUAL(socket.accept_event_data.event, &socket.accept_event);
@@ -61,10 +61,10 @@ void test_transport_create_socket_should_add_accept_event_to_event_system() {
     rasta_transport_channel channel = {0};
     rasta_config_tls tls_config = {0};
 
-    transport_init(&h, &channel, 100, "127.0.0.1", 4711, &tls_config);
+    transport_init(&h, &channel, 0, "127.0.0.1", 4711, &tls_config);
 
     // Act
-    transport_create_socket(&h, &socket, 42, &tls_config);
+    transport_create_socket(&h, &socket, 0, &tls_config);
 
     // Assert
     CU_ASSERT_PTR_EQUAL(event_system.fd_events.last, &socket.accept_event);
@@ -86,8 +86,8 @@ void test_transport_listen_should_enable_socket_accept_event() {
         .key_path = "../examples/server.key",
     };
 
-    transport_init(&h, &channel, 100, "127.0.0.1", 4711, &tls_config);
-    transport_create_socket(&h, &socket, 42, &tls_config);
+    transport_init(&h, &channel, 0, "127.0.0.1", 4711, &tls_config);
+    transport_create_socket(&h, &socket, 0, &tls_config);
 
     // Assert
     CU_ASSERT_FALSE(socket.accept_event.enabled);
@@ -115,8 +115,8 @@ void test_transport_connect_should_enable_channel_receive_event() {
         .key_path = "../examples/server.key",
     };
 
-    transport_init(&h, &channel, 100, "127.0.0.1", 4711, &tls_config);
-    transport_create_socket(&h, &socket, 42, &tls_config);
+    transport_init(&h, &channel, 0, "127.0.0.1", 4711, &tls_config);
+    transport_create_socket(&h, &socket, 0, &tls_config);
 
     // Assert
     CU_ASSERT_FALSE(channel.receive_event.enabled);
@@ -144,8 +144,8 @@ void test_transport_close_channel_should_set_unconnected() {
         .key_path = "../examples/server.key",
     };
 
-    transport_init(&h, &channel, 100, "127.0.0.1", 4711, &tls_config);
-    transport_create_socket(&h, &socket, 42, &tls_config);
+    transport_init(&h, &channel, 0, "127.0.0.1", 4711, &tls_config);
+    transport_create_socket(&h, &socket, 0, &tls_config);
     transport_connect(&socket, &channel);
 
     // Assert
@@ -174,8 +174,8 @@ void test_transport_close_channel_should_invalidate_fd() {
         .key_path = "../examples/server.key",
     };
 
-    transport_init(&h, &channel, 100, "127.0.0.1", 4711, &tls_config);
-    transport_create_socket(&h, &socket, 42, &tls_config);
+    transport_init(&h, &channel, 0, "127.0.0.1", 4711, &tls_config);
+    transport_create_socket(&h, &socket, 0, &tls_config);
     transport_connect(&socket, &channel);
 
     // Act
@@ -201,8 +201,8 @@ void test_transport_close_channel_should_disable_channel_receive_event() {
         .key_path = "../examples/server.key",
     };
 
-    transport_init(&h, &channel, 100, "127.0.0.1", 4711, &tls_config);
-    transport_create_socket(&h, &socket, 42, &tls_config);
+    transport_init(&h, &channel, 0, "127.0.0.1", 4711, &tls_config);
+    transport_create_socket(&h, &socket, 0, &tls_config);
     transport_connect(&socket, &channel);
 
     // Act
@@ -240,8 +240,8 @@ void test_transport_redial_should_reconnect() {
     config.redundancy = red_config;
     h.mux.config = &config;
 
-    transport_init(&h, &channel, 100, "127.0.0.1", 4711, &tls_config);
-    transport_create_socket(&h, &socket, 42, &tls_config);
+    transport_init(&h, &channel, 0, "127.0.0.1", 4711, &tls_config);
+    transport_create_socket(&h, &socket, 0, &tls_config);
     transport_connect(&socket, &channel);
     transport_close_channel(&channel);
 
@@ -280,8 +280,8 @@ void test_transport_redial_should_assign_new_fds() {
     config.redundancy = red_config;
     h.mux.config = &config;
 
-    transport_init(&h, &channel, 100, "127.0.0.1", 4711, &tls_config);
-    transport_create_socket(&h, &socket, 42, &tls_config);
+    transport_init(&h, &channel, 0, "127.0.0.1", 4711, &tls_config);
+    transport_create_socket(&h, &socket, 0, &tls_config);
     transport_connect(&socket, &channel);
     transport_close_channel(&channel);
 
@@ -321,8 +321,8 @@ void test_transport_redial_should_update_event_fds() {
     config.redundancy = red_config;
     h.mux.config = &config;
 
-    transport_init(&h, &channel, 100, "127.0.0.1", 4711, &tls_config);
-    transport_create_socket(&h, &socket, 42, &tls_config);
+    transport_init(&h, &channel, 0, "127.0.0.1", 4711, &tls_config);
+    transport_create_socket(&h, &socket, 0, &tls_config);
     transport_connect(&socket, &channel);
     transport_close_channel(&channel);
 

--- a/test/rasta_transport_test/c/transport_test_udp.c
+++ b/test/rasta_transport_test/c/transport_test_udp.c
@@ -14,10 +14,10 @@ void test_transport_create_socket_should_initialize_receive_event() {
     rasta_transport_channel channel = {0};
     rasta_config_tls tls_config = {0};
 
-    transport_init(&h, &channel, 100, "127.0.0.1", 4711, &tls_config);
+    transport_init(&h, &channel, 0, "127.0.0.1", 4711, &tls_config);
 
     // Act
-    transport_create_socket(&h, &socket, 42, &tls_config);
+    transport_create_socket(&h, &socket, 0, &tls_config);
 
     // Assert
     CU_ASSERT_PTR_EQUAL(socket.receive_event.callback, channel_receive_event);
@@ -36,10 +36,10 @@ void test_transport_create_socket_should_initialize_receive_event_data() {
     rasta_transport_channel channel = {0};
     rasta_config_tls tls_config = {0};
 
-    transport_init(&h, &channel, 100, "127.0.0.1", 4711, &tls_config);
+    transport_init(&h, &channel, 0, "127.0.0.1", 4711, &tls_config);
 
     // Act
-    transport_create_socket(&h, &socket, 42, &tls_config);
+    transport_create_socket(&h, &socket, 0, &tls_config);
 
     // Assert
     CU_ASSERT_PTR_EQUAL(socket.receive_event_data.socket, &socket);
@@ -61,10 +61,10 @@ void test_transport_create_socket_should_add_receive_event_to_event_system() {
     rasta_transport_channel channel = {0};
     rasta_config_tls tls_config = {0};
 
-    transport_init(&h, &channel, 100, "127.0.0.1", 4711, &tls_config);
+    transport_init(&h, &channel, 0, "127.0.0.1", 4711, &tls_config);
 
     // Act
-    transport_create_socket(&h, &socket, 42, &tls_config);
+    transport_create_socket(&h, &socket, 0, &tls_config);
 
     // Assert
     CU_ASSERT_PTR_EQUAL(event_system.fd_events.last, &socket.receive_event);
@@ -86,8 +86,8 @@ void test_transport_listen_should_enable_socket_receive_event() {
         .key_path = "../examples/server.key",
     };
 
-    transport_init(&h, &channel, 100, "127.0.0.1", 4711, &tls_config);
-    transport_create_socket(&h, &socket, 42, &tls_config);
+    transport_init(&h, &channel, 0, "127.0.0.1", 4711, &tls_config);
+    transport_create_socket(&h, &socket, 0, &tls_config);
 
     // Assert
     CU_ASSERT_FALSE(socket.receive_event.enabled);
@@ -115,8 +115,8 @@ void test_transport_connect_should_enable_socket_receive_event() {
         .key_path = "../examples/server.key",
     };
 
-    transport_init(&h, &channel, 100, "127.0.0.1", 4711, &tls_config);
-    transport_create_socket(&h, &socket, 42, &tls_config);
+    transport_init(&h, &channel, 0, "127.0.0.1", 4711, &tls_config);
+    transport_create_socket(&h, &socket, 0, &tls_config);
 
     // Assert
     CU_ASSERT_FALSE(socket.receive_event.enabled);


### PR DESCRIPTION
This closes #60 and fixes most of the memory problems discovered with Valgrind. 

To run Valgrind on the tests, use `ctest . -T memcheck` (from the build folder). To run Valgrind for any other executable, use `valgrind --leak-check=full --show-leak-kinds=all <executable>`. If you are in a VS Code Devcontainer and get a weird segfault, run `ulimit -n 1024` and then try again.