### PR TITLE
Use vcpkg for dependency management

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vcpkg"]
+	path = vcpkg
+	url = https://github.com/microsoft/vcpkg

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,9 @@
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "vcpkg",
+            "toolchainFile": "vcpkg/scripts/buildsystems/vcpkg.cmake"
+        }
+    ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,6 +3,7 @@
     "configurePresets": [
         {
             "name": "vcpkg",
+            "binaryDir": "build",
             "toolchainFile": "vcpkg/scripts/buildsystems/vcpkg.cmake"
         }
     ]

--- a/cmake/Findsodium.cmake
+++ b/cmake/Findsodium.cmake
@@ -225,7 +225,7 @@ endif()
 # communicate results
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
-    Sodium # The name must be either uppercase or match the filename case.
+    sodium # The name must be either uppercase or match the filename case.
     REQUIRED_VARS
         sodium_LIBRARY_RELEASE
         sodium_LIBRARY_DEBUG

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(ENABLE_RASTA_TLS)
     find_package(WolfSSL REQUIRED)
     include(CheckSymbolExists)
-    check_symbol_exists(HAVE_SECRET_CALLBACK "wolfssl/options.h" WOLFSSL_SET_TLS13_SECRET_CB_EXISTS)
+    check_symbol_exists(HAVE_SECRET_CALLBACK "${WolfSSL_INCLUDE_DIRS}/wolfssl/options.h" WOLFSSL_SET_TLS13_SECRET_CB_EXISTS)
     if(WOLFSSL_SET_TLS13_SECRET_CB_EXISTS)
         add_compile_definitions("WOLFSSL_SET_TLS13_SECRET_CB_EXISTS")
         message("Found method wolfSSL_set_tls13_secret_cb - can provide TLS keys for debugging!")

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,7 @@
+{
+    "dependencies": [
+        "wolfssl",
+        "libsodium",
+        "grpc"
+    ]
+}


### PR DESCRIPTION
This closes #59. 

How to use: `git submodule update --init && ./vcpkg/bootstrap-vcpkg.sh --disableMetrics` to install vcpkg and then configure CMake with `--preset vcpkg` (this automatically installs required packages). Now the build process should use vcpkg dependencies.

TODO:
* Use vcpkg in the CI config and Dockerfiles