### PR TITLE
Make rasta receive message buffer size configurable

### DIFF
--- a/examples/common/c/configfile.c
+++ b/examples/common/c/configfile.c
@@ -593,6 +593,19 @@ void config_setstd(struct RastaConfig *cfg) {
     }
 
     /*
+     * Receive recv message size
+     */
+
+    entr = config_get(cfg, "RASTA_RECV_MSG_SIZE");
+    if (entr.type != DICTIONARY_NUMBER || entr.value.number < 0) {
+        // set std
+        cfg->values.receive.max_recv_msg_size = 500;
+    } else {
+        // check valid format
+        cfg->values.receive.max_recv_msg_size = (unsigned int)entr.value.number;
+    }
+
+    /*
      * Retransmission part
      */
 

--- a/src/include/rasta/config.h
+++ b/src/include/rasta/config.h
@@ -39,6 +39,7 @@ typedef struct rasta_config_sending {
  */
 typedef struct rasta_config_receive {
     unsigned int max_recvqueue_size;
+    unsigned int max_recv_msg_size;
 } rasta_config_receive;
 
 /**

--- a/test/rasta_test/c/config_test.c
+++ b/test/rasta_test/c/config_test.c
@@ -40,6 +40,7 @@ void check_std_config() {
 
     // check receive
     CU_ASSERT_EQUAL(cfg.values.receive.max_recvqueue_size, 20);
+    CU_ASSERT_EQUAL(cfg.values.receive.max_recv_msg_size, 500);
 
     // check retransmission
     CU_ASSERT_EQUAL(cfg.values.retransmission.max_retransmission_queue_size, 100);
@@ -74,6 +75,7 @@ void check_var_config() {
     fprintf(f, "RASTA_DIAG_WINDOW = 6000\n");
 
     fprintf(f, "RASTA_RECVQUEUE_SIZE = 42\n");
+    fprintf(f, "RASTA_RECV_MSG_SIZE = 1337\n");
 
     fprintf(f, "RASTA_RETRANSMISSION_QUEUE_SIZE = 50\n");
 
@@ -111,6 +113,7 @@ void check_var_config() {
 
     // check receive
     CU_ASSERT_EQUAL(cfg.values.receive.max_recvqueue_size, 42);
+    CU_ASSERT_EQUAL(cfg.values.receive.max_recv_msg_size, 1337);
 
     // check retransmission
     CU_ASSERT_EQUAL(cfg.values.retransmission.max_retransmission_queue_size, 50);


### PR DESCRIPTION
This makes the previously hard coded `BUF_SIZE` in the grpb_bridge configurable via a _rast_config.cfg_ file.