### PR TITLE
Build arm64 images on circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/configuration-reference
+version: 2.1
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/configuration-reference/#jobs
+jobs:
+  say-hello:
+    # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
+    # See: https://circleci.com/docs/configuration-reference/#executor-job
+    docker:
+      - image: cimg/base:stable
+    # Add steps to the job
+    # See: https://circleci.com/docs/configuration-reference/#steps
+    steps:
+      - checkout
+      - run:
+          name: "Say hello"
+          command: "echo Hello, World!"
+
+# Orchestrate jobs using workflows
+# See: https://circleci.com/docs/configuration-reference/#workflows
+workflows:
+  say-hello-workflow:
+    jobs:
+      - say-hello

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,35 @@
 version: 2.1
+jobs:
+  build:
+    resource_class: arm.medium
+    docker:
+      - image: cimg/base:2023.12
+        auth:
+          username: $GHCR_USERNAME
+          password: $GHCR_PASSWORD
+    steps:
+      - checkout
+      - setup_remote_docker
+      - restore_cache:
+          keys:
+            - v1-{{ .Branch }}
+      - run:
+          name: Load Docker image layer cache
+          command: |
+            set +o pipefail
+            docker load -i /caches/app.tar | true
+      - run:
+          name: Build and Push application Docker image
+          command: |
+            docker build -t ghcr.io/librasta/rasta_grpc_bridge_udp:main --target udp -f docker/rasta_grpc_bridge/Dockerfile .
+            docker build -t ghcr.io/librasta/rasta_grpc_bridge_tcp:main --target tcp -f docker/rasta_grpc_bridge/Dockerfile .
+            docker build -t ghcr.io/librasta/rasta_grpc_bridge_dtls:main --target dtls -f docker/rasta_grpc_bridge/Dockerfile .
+            docker build -t ghcr.io/librasta/rasta_grpc_bridge_tls:main --target tls -f docker/rasta_grpc_bridge/Dockerfile .
+            echo $GHCR_PASSWORD | docker login ghcr.io -u $GHCR_USERNAME --password-stdin
+            docker push ghcr.io/librasta/rasta_grpc_bridge_udp:main
+            docker push ghcr.io/librasta/rasta_grpc_bridge_tcp:main
+            docker push ghcr.io/librasta/rasta_grpc_bridge_dtls:main
+            docker push ghcr.io/librasta/rasta_grpc_bridge_tls:main
 workflows:
   build:
     jobs:
@@ -7,32 +38,3 @@ workflows:
             branches:
               only:
                 - circleci-project-setup
-          resource_class: arm.medium
-          docker:
-            - image: cimg/base:2023.12
-              auth:
-                username: $GHCR_USERNAME
-                password: $GHCR_PASSWORD
-          steps:
-            - checkout
-            - setup_remote_docker
-            - restore_cache:
-                keys:
-                  - v1-{{ .Branch }}
-            - run:
-                name: Load Docker image layer cache
-                command: |
-                  set +o pipefail
-                  docker load -i /caches/app.tar | true
-            - run:
-                name: Build and Push application Docker image
-                command: |
-                  docker build -t ghcr.io/librasta/rasta_grpc_bridge_udp:main --target udp -f docker/rasta_grpc_bridge/Dockerfile .
-                  docker build -t ghcr.io/librasta/rasta_grpc_bridge_tcp:main --target tcp -f docker/rasta_grpc_bridge/Dockerfile .
-                  docker build -t ghcr.io/librasta/rasta_grpc_bridge_dtls:main --target dtls -f docker/rasta_grpc_bridge/Dockerfile .
-                  docker build -t ghcr.io/librasta/rasta_grpc_bridge_tls:main --target tls -f docker/rasta_grpc_bridge/Dockerfile .
-                  echo $GHCR_PASSWORD | docker login ghcr.io -u $GHCR_USERNAME --password-stdin
-                  docker push ghcr.io/librasta/rasta_grpc_bridge_udp:main
-                  docker push ghcr.io/librasta/rasta_grpc_bridge_tcp:main
-                  docker push ghcr.io/librasta/rasta_grpc_bridge_dtls:main
-                  docker push ghcr.io/librasta/rasta_grpc_bridge_tls:main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,16 @@
 version: 2.1
 jobs:
   build:
+    filters:
+      branches:
+        only:
+          - circleci-project-setup
     resource_class: arm.medium
     docker:
       - image: cimg/base:2023.12
+        auth:
+          username: $GHCR_USERNAME
+          password: $GHCR_PASSWORD
     steps:
       - checkout
       - setup_remote_docker
@@ -18,4 +25,12 @@ jobs:
       - run:
           name: Build and Push application Docker image
           command: |
-            docker build -t librasta/rasta_grpc_bridge_udp:latest --target udp -f docker/rasta_grpc_bridge/Dockerfile .
+            docker build -t ghcr.io/librasta/rasta_grpc_bridge_udp:main --target udp -f docker/rasta_grpc_bridge/Dockerfile .
+            docker build -t ghcr.io/librasta/rasta_grpc_bridge_tcp:main --target tcp -f docker/rasta_grpc_bridge/Dockerfile .
+            docker build -t ghcr.io/librasta/rasta_grpc_bridge_dtls:main --target dtls -f docker/rasta_grpc_bridge/Dockerfile .
+            docker build -t ghcr.io/librasta/rasta_grpc_bridge_tls:main --target tls -f docker/rasta_grpc_bridge/Dockerfile .
+            echo $GHCR_PASSWORD | docker login ghcr.io -u $GHCR_USERNAME --password-stdin
+            docker push ghcr.io/librasta/rasta_grpc_bridge_udp:main
+            docker push ghcr.io/librasta/rasta_grpc_bridge_tcp:main
+            docker push ghcr.io/librasta/rasta_grpc_bridge_dtls:main
+            docker push ghcr.io/librasta/rasta_grpc_bridge_tls:main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,14 +17,14 @@ jobs:
           name: Build and Push application Docker image
           command: |
             echo $GHCR_PASSWORD | docker login ghcr.io -u $GHCR_USERNAME --password-stdin
-            docker build -t ghcr.io/librasta/rasta_grpc_bridge_udp:main --target udp -f docker/rasta_grpc_bridge/Dockerfile .
-            docker build -t ghcr.io/librasta/rasta_grpc_bridge_tcp:main --target tcp -f docker/rasta_grpc_bridge/Dockerfile .
-            docker build -t ghcr.io/librasta/rasta_grpc_bridge_dtls:main --target dtls -f docker/rasta_grpc_bridge/Dockerfile .
-            docker build -t ghcr.io/librasta/rasta_grpc_bridge_tls:main --target tls -f docker/rasta_grpc_bridge/Dockerfile .
-            docker push ghcr.io/librasta/rasta_grpc_bridge_udp:main
-            docker push ghcr.io/librasta/rasta_grpc_bridge_tcp:main
-            docker push ghcr.io/librasta/rasta_grpc_bridge_dtls:main
-            docker push ghcr.io/librasta/rasta_grpc_bridge_tls:main
+            docker build -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_udp:main --target udp -f docker/rasta_grpc_bridge/Dockerfile .
+            docker build -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tcp:main --target tcp -f docker/rasta_grpc_bridge/Dockerfile .
+            docker build -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_dtls:main --target dtls -f docker/rasta_grpc_bridge/Dockerfile .
+            docker build -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tls:main --target tls -f docker/rasta_grpc_bridge/Dockerfile .
+            docker push ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_udp:main
+            docker push ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tcp:main
+            docker push ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_dtls:main
+            docker push ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tls:main
 workflows:
   build:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,6 @@ jobs:
     resource_class: arm.medium
     docker:
       - image: cimg/base:2023.12
-        auth:
-          username: $GHCR_USERNAME
-          password: $GHCR_PASSWORD
     steps:
       - checkout
       - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,10 @@ jobs:
           name: Build and Push application Docker image
           command: |
             echo $GHCR_PASSWORD | docker login ghcr.io -u $GHCR_USERNAME --password-stdin
-            docker buildx build -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_udp:main --target udp -f docker/rasta_grpc_bridge/Dockerfile .
-            docker buildx build -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tcp:main --target tcp -f docker/rasta_grpc_bridge/Dockerfile .
-            docker buildx build -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_dtls:main --target dtls -f docker/rasta_grpc_bridge/Dockerfile .
-            docker buildx build -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tls:main --target tls -f docker/rasta_grpc_bridge/Dockerfile .
+            docker buildx build --platform linux/arm64 -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_udp:main --target udp -f docker/rasta_grpc_bridge/Dockerfile .
+            docker buildx build --platform linux/arm64 -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tcp:main --target tcp -f docker/rasta_grpc_bridge/Dockerfile .
+            docker buildx build --platform linux/arm64 -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_dtls:main --target dtls -f docker/rasta_grpc_bridge/Dockerfile .
+            docker buildx build --platform linux/arm64 -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tls:main --target tls -f docker/rasta_grpc_bridge/Dockerfile .
             docker push ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_udp:main
             docker push ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tcp:main
             docker push ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_dtls:main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,36 +1,38 @@
 version: 2.1
-jobs:
+workflows:
   build:
-    filters:
-      branches:
-        only:
-          - circleci-project-setup
-    resource_class: arm.medium
-    docker:
-      - image: cimg/base:2023.12
-        auth:
-          username: $GHCR_USERNAME
-          password: $GHCR_PASSWORD
-    steps:
-      - checkout
-      - setup_remote_docker
-      - restore_cache:
-          keys:
-            - v1-{{ .Branch }}
-      - run:
-          name: Load Docker image layer cache
-          command: |
-            set +o pipefail
-            docker load -i /caches/app.tar | true
-      - run:
-          name: Build and Push application Docker image
-          command: |
-            docker build -t ghcr.io/librasta/rasta_grpc_bridge_udp:main --target udp -f docker/rasta_grpc_bridge/Dockerfile .
-            docker build -t ghcr.io/librasta/rasta_grpc_bridge_tcp:main --target tcp -f docker/rasta_grpc_bridge/Dockerfile .
-            docker build -t ghcr.io/librasta/rasta_grpc_bridge_dtls:main --target dtls -f docker/rasta_grpc_bridge/Dockerfile .
-            docker build -t ghcr.io/librasta/rasta_grpc_bridge_tls:main --target tls -f docker/rasta_grpc_bridge/Dockerfile .
-            echo $GHCR_PASSWORD | docker login ghcr.io -u $GHCR_USERNAME --password-stdin
-            docker push ghcr.io/librasta/rasta_grpc_bridge_udp:main
-            docker push ghcr.io/librasta/rasta_grpc_bridge_tcp:main
-            docker push ghcr.io/librasta/rasta_grpc_bridge_dtls:main
-            docker push ghcr.io/librasta/rasta_grpc_bridge_tls:main
+    jobs:
+      - build:
+          filters:
+            branches:
+              only:
+                - circleci-project-setup
+          resource_class: arm.medium
+          docker:
+            - image: cimg/base:2023.12
+              auth:
+                username: $GHCR_USERNAME
+                password: $GHCR_PASSWORD
+          steps:
+            - checkout
+            - setup_remote_docker
+            - restore_cache:
+                keys:
+                  - v1-{{ .Branch }}
+            - run:
+                name: Load Docker image layer cache
+                command: |
+                  set +o pipefail
+                  docker load -i /caches/app.tar | true
+            - run:
+                name: Build and Push application Docker image
+                command: |
+                  docker build -t ghcr.io/librasta/rasta_grpc_bridge_udp:main --target udp -f docker/rasta_grpc_bridge/Dockerfile .
+                  docker build -t ghcr.io/librasta/rasta_grpc_bridge_tcp:main --target tcp -f docker/rasta_grpc_bridge/Dockerfile .
+                  docker build -t ghcr.io/librasta/rasta_grpc_bridge_dtls:main --target dtls -f docker/rasta_grpc_bridge/Dockerfile .
+                  docker build -t ghcr.io/librasta/rasta_grpc_bridge_tls:main --target tls -f docker/rasta_grpc_bridge/Dockerfile .
+                  echo $GHCR_PASSWORD | docker login ghcr.io -u $GHCR_USERNAME --password-stdin
+                  docker push ghcr.io/librasta/rasta_grpc_bridge_udp:main
+                  docker push ghcr.io/librasta/rasta_grpc_bridge_tcp:main
+                  docker push ghcr.io/librasta/rasta_grpc_bridge_dtls:main
+                  docker push ghcr.io/librasta/rasta_grpc_bridge_tls:main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,11 +16,11 @@ jobs:
       - run:
           name: Build and Push application Docker image
           command: |
+            echo $GHCR_PASSWORD | docker login ghcr.io -u $GHCR_USERNAME --password-stdin
             docker build -t ghcr.io/librasta/rasta_grpc_bridge_udp:main --target udp -f docker/rasta_grpc_bridge/Dockerfile .
             docker build -t ghcr.io/librasta/rasta_grpc_bridge_tcp:main --target tcp -f docker/rasta_grpc_bridge/Dockerfile .
             docker build -t ghcr.io/librasta/rasta_grpc_bridge_dtls:main --target dtls -f docker/rasta_grpc_bridge/Dockerfile .
             docker build -t ghcr.io/librasta/rasta_grpc_bridge_tls:main --target tls -f docker/rasta_grpc_bridge/Dockerfile .
-            echo $GHCR_PASSWORD | docker login ghcr.io -u $GHCR_USERNAME --password-stdin
             docker push ghcr.io/librasta/rasta_grpc_bridge_udp:main
             docker push ghcr.io/librasta/rasta_grpc_bridge_tcp:main
             docker push ghcr.io/librasta/rasta_grpc_bridge_dtls:main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,6 @@
 version: 2.1
 jobs:
   build:
-    machine:
-      image: ubuntu-2204:2023.07.1
     resource_class: arm.medium
     docker:
       - image: cimg/base:2022.09

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,9 @@
 version: 2.1
 jobs:
   build:
+    machine:
+      image: ubuntu-2204:2023.07.1
+    resource_class: arm.medium
     docker:
       - image: cimg/base:2022.09
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,26 +1,20 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine.
-# See: https://circleci.com/docs/configuration-reference
 version: 2.1
-
-# Define a job to be invoked later in a workflow.
-# See: https://circleci.com/docs/configuration-reference/#jobs
 jobs:
-  say-hello:
-    # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
-    # See: https://circleci.com/docs/configuration-reference/#executor-job
+  build:
     docker:
-      - image: cimg/base:stable
-    # Add steps to the job
-    # See: https://circleci.com/docs/configuration-reference/#steps
+      - image: cimg/base:2022.09
     steps:
       - checkout
+      - setup_remote_docker
+      - restore_cache:
+          keys:
+            - v1-{{ .Branch }}
       - run:
-          name: "Say hello"
-          command: "echo Hello, World!"
-
-# Orchestrate jobs using workflows
-# See: https://circleci.com/docs/configuration-reference/#workflows
-workflows:
-  say-hello-workflow:
-    jobs:
-      - say-hello
+          name: Load Docker image layer cache
+          command: |
+            set +o pipefail
+            docker load -i /caches/app.tar | true
+      - run:
+          name: Build and Push application Docker image
+          command: |
+            docker build -t librasta/rasta_grpc_bridge_udp:latest --target udp -f docker/rasta_grpc_bridge/Dockerfile .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,18 +9,13 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          name: Load Docker image layer cache
-          command: |
-            set +o pipefail
-            docker load -i /caches/app.tar | true
-      - run:
           name: Build and Push application Docker image
           command: |
             echo $GHCR_PASSWORD | docker login ghcr.io -u $GHCR_USERNAME --password-stdin
-            docker build -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_udp:main --target udp -f docker/rasta_grpc_bridge/Dockerfile .
-            docker build -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tcp:main --target tcp -f docker/rasta_grpc_bridge/Dockerfile .
-            docker build -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_dtls:main --target dtls -f docker/rasta_grpc_bridge/Dockerfile .
-            docker build -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tls:main --target tls -f docker/rasta_grpc_bridge/Dockerfile .
+            docker buildx build -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_udp:main --target udp -f docker/rasta_grpc_bridge/Dockerfile .
+            docker buildx build -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tcp:main --target tcp -f docker/rasta_grpc_bridge/Dockerfile .
+            docker buildx build -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_dtls:main --target dtls -f docker/rasta_grpc_bridge/Dockerfile .
+            docker buildx build -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tls:main --target tls -f docker/rasta_grpc_bridge/Dockerfile .
             docker push ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_udp:main
             docker push ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tcp:main
             docker push ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_dtls:main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,4 +42,4 @@ workflows:
           filters:
             branches:
               only:
-                - circleci-project-setup
+                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,15 +11,30 @@ jobs:
       - run:
           name: Build and Push application Docker image
           command: |
+            TAG=main-arm64
+            SHA=$(git rev-parse HEAD)
+            SHORTSHA="${SHA:0:7}"
+            SHA_TAG=sha-$SHORTSHA-arm64
             echo $GHCR_PASSWORD | docker login ghcr.io -u $GHCR_USERNAME --password-stdin
-            docker buildx build --platform linux/arm64 -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_udp:main --target udp -f docker/rasta_grpc_bridge/Dockerfile .
-            docker buildx build --platform linux/arm64 -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tcp:main --target tcp -f docker/rasta_grpc_bridge/Dockerfile .
-            docker buildx build --platform linux/arm64 -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_dtls:main --target dtls -f docker/rasta_grpc_bridge/Dockerfile .
-            docker buildx build --platform linux/arm64 -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tls:main --target tls -f docker/rasta_grpc_bridge/Dockerfile .
-            docker push ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_udp:main
-            docker push ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tcp:main
-            docker push ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_dtls:main
-            docker push ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tls:main
+            docker buildx build --platform linux/arm64 -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_udp:$TAG --target udp -f docker/rasta_grpc_bridge/Dockerfile .
+            docker buildx build --platform linux/arm64 -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tcp:$TAG --target tcp -f docker/rasta_grpc_bridge/Dockerfile .
+            docker buildx build --platform linux/arm64 -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_dtls:$TAG --target dtls -f docker/rasta_grpc_bridge/Dockerfile .
+            docker buildx build --platform linux/arm64 -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tls:$TAG --target tls -f docker/rasta_grpc_bridge/Dockerfile .
+
+            docker buildx build --platform linux/arm64 -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_udp:$SHA_TAG --target udp -f docker/rasta_grpc_bridge/Dockerfile .
+            docker buildx build --platform linux/arm64 -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tcp:$SHA_TAG --target tcp -f docker/rasta_grpc_bridge/Dockerfile .
+            docker buildx build --platform linux/arm64 -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_dtls:$SHA_TAG --target dtls -f docker/rasta_grpc_bridge/Dockerfile .
+            docker buildx build --platform linux/arm64 -t ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tls:$SHA_TAG --target tls -f docker/rasta_grpc_bridge/Dockerfile .
+
+            docker push ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_udp:$TAG
+            docker push ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tcp:$TAG
+            docker push ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_dtls:$TAG
+            docker push ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tls:$TAG
+
+            docker push ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_udp:$SHA_TAG
+            docker push ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tcp:$SHA_TAG
+            docker push ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_dtls:$SHA_TAG
+            docker push ghcr.io/eulynx-live/librasta/rasta_grpc_bridge_tls:$SHA_TAG
 workflows:
   build:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     resource_class: arm.medium
     docker:
-      - image: cimg/base:2022.09
+      - image: cimg/base:2023.12
     steps:
       - checkout
       - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,8 @@ jobs:
       - image: cimg/base:2023.12
     steps:
       - checkout
-      - setup_remote_docker
-      - restore_cache:
-          keys:
-            - v1-{{ .Branch }}
+      - setup_remote_docker:
+          docker_layer_caching: true
       - run:
           name: Load Docker image layer cache
           command: |


### PR DESCRIPTION
This adds a configuration to have arm64 container images available. Since I didn't want to mess around with docker manifests and race conditions between the circle CI and GitHub runners, I chose to use separate tags for the new images.