### PR TITLE
Remove PATH_MAX in public header files

### DIFF
--- a/examples/common/c/configfile.c
+++ b/examples/common/c/configfile.c
@@ -661,22 +661,22 @@ void config_setstd(struct RastaConfig *cfg) {
     entr = config_get(cfg, "RASTA_CA_PATH");
     cfg->values.tls.ca_cert_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
-        cfg->values.tls.ca_cert_path = malloc(strnlen(entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES));
-        strncpy(cfg->values.tls.ca_cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES - 1);
+        cfg->values.tls.ca_cert_path = malloc(MAX_DICTIONARY_STRING_LENGTH_BYTES);
+        strncpy(cfg->values.tls.ca_cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES);
     }
 
     entr = config_get(cfg, "RASTA_CERT_PATH");
     cfg->values.tls.cert_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
-        cfg->values.tls.cert_path = malloc(strnlen(entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES));
-        strncpy(cfg->values.tls.cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES - 1);
+        cfg->values.tls.cert_path = malloc(MAX_DICTIONARY_STRING_LENGTH_BYTES);
+        strncpy(cfg->values.tls.cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES);
     }
 
     entr = config_get(cfg, "RASTA_KEY_PATH");
     cfg->values.tls.key_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
-        cfg->values.tls.key_path = malloc(strnlen(entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES));
-        strncpy(cfg->values.tls.key_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES - 1);
+        cfg->values.tls.key_path = malloc(MAX_DICTIONARY_STRING_LENGTH_BYTES);
+        strncpy(cfg->values.tls.key_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES);
     }
 
 #ifdef ENABLE_TLS
@@ -688,8 +688,8 @@ void config_setstd(struct RastaConfig *cfg) {
     entr = config_get(cfg, "RASTA_TLS_PEER_CERT_PATH");
     cfg->values.tls.peer_tls_cert_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
-        cfg->values.tls.peer_tls_cert_path = malloc(strnlen(entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES));
-        strncpy(cfg->values.tls.peer_tls_cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES - 1);
+        cfg->values.tls.peer_tls_cert_path = malloc(MAX_DICTIONARY_STRING_LENGTH_BYTES);
+        strncpy(cfg->values.tls.peer_tls_cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES);
     }
 #endif
 

--- a/examples/common/c/configfile.c
+++ b/examples/common/c/configfile.c
@@ -64,7 +64,7 @@ int parser_next(struct LineParser *p) {
  * increases the parser position until
  * @param p
  */
-void parser_skipBlanc(struct LineParser *p) {
+void parser_skipBlank(struct LineParser *p) {
     while (p->current == ' ' || p->current == '\t') {
         if (!parser_next(p)) {
             logger_log(&p->cfg->logger, LOG_LEVEL_ERROR, p->cfg->filename, "Error in line %d: Reached unexpected end of line", p->line);
@@ -79,7 +79,7 @@ void parser_skipBlanc(struct LineParser *p) {
  * @param identifier pointer to the output
  */
 void parser_parseIdentifier(struct LineParser *p, char *identifier) {
-    parser_skipBlanc(p);
+    parser_skipBlank(p);
     int i = 0;
     while (isdigit(p->current) || isalpha(p->current) || (p->current == '_')) {
         if (i >= MAX_DICTIONARY_STRING_LENGTH_BYTES - 1) {
@@ -213,7 +213,7 @@ int parser_parseArray(struct LineParser *p, struct DictionaryArray *array) {
 
     unsigned int i = 0;
     while (p->current != '}') {
-        parser_skipBlanc(p);
+        parser_skipBlank(p);
         // skip number arrays
         if (p->current == '0' || p->current == '1' || p->current == '2' || p->current == '3' || p->current == '4' || p->current == '5' || p->current == '6' || p->current == '7' || p->current == '8' || p->current == '9') {
             return 1;
@@ -235,7 +235,7 @@ int parser_parseArray(struct LineParser *p, struct DictionaryArray *array) {
         i++;
 
         if (p->current == '"') parser_next(p);
-        parser_skipBlanc(p);
+        parser_skipBlank(p);
         if (p->current == ';' || p->current == ',') {
             parser_next(p);
             continue;
@@ -260,7 +260,7 @@ int parser_parseArray(struct LineParser *p, struct DictionaryArray *array) {
  */
 void parser_parseValue(struct LineParser *p, const char key[MAX_DICTIONARY_STRING_LENGTH_BYTES]) {
     // skip empty start
-    parser_skipBlanc(p);
+    parser_skipBlank(p);
 
     if (p->current == '-' || isdigit(p->current)) {
         // parse number
@@ -659,21 +659,27 @@ void config_setstd(struct RastaConfig *cfg) {
     // TLS settings
 
     entr = config_get(cfg, "RASTA_CA_PATH");
+    cfg->values.tls.ca_cert_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
-        cfg->values.tls.ca_cert_path[PATH_MAX - 1] = 0;
-        memcpy(cfg->values.tls.ca_cert_path, entr.value.string.c, PATH_MAX);
+        char *ca_path = malloc(strnlen(entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES) + 1);
+        strncpy(ca_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES);
+        cfg->values.tls.ca_cert_path = ca_path;
     }
 
     entr = config_get(cfg, "RASTA_CERT_PATH");
+    cfg->values.tls.cert_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
-        cfg->values.tls.cert_path[PATH_MAX - 1] = 0;
-        memcpy(cfg->values.tls.cert_path, entr.value.string.c, PATH_MAX);
+        char *cert_path = malloc(strnlen(entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES) + 1);
+        strncpy(cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES);
+        cfg->values.tls.cert_path = cert_path;
     }
 
     entr = config_get(cfg, "RASTA_KEY_PATH");
+    cfg->values.tls.key_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
-        cfg->values.tls.key_path[PATH_MAX - 1] = 0;
-        memcpy(cfg->values.tls.key_path, entr.value.string.c, PATH_MAX);
+        char *key_path = malloc(strnlen(entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES) + 1);
+        strncpy(key_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES);
+        cfg->values.tls.key_path = key_path;
     }
 
 #ifdef ENABLE_TLS
@@ -683,8 +689,11 @@ void config_setstd(struct RastaConfig *cfg) {
         memcpy(cfg->values.tls.tls_hostname, entr.value.string.c, MAX_DOMAIN_LENGTH);
     }
     entr = config_get(cfg, "RASTA_TLS_PEER_CERT_PATH");
+    cfg->values.tls.peer_tls_cert_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
-        memcpy(cfg->values.tls.peer_tls_cert_path, entr.value.string.c, PATH_MAX);
+        char *peer_tls_cert_path = malloc(strnlen(entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES) + 1);
+        strncpy(peer_tls_cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES);
+        cfg->values.tls.peer_tls_cert_path = peer_tls_cert_path;
     }
 #endif
 
@@ -775,7 +784,7 @@ int config_load(struct RastaConfig *config, const char *filename) {
         parser_init(&p, buf, n, config);
 
         // skip empty start
-        parser_skipBlanc(&p);
+        parser_skipBlank(&p);
 
         // ignore comments
         if (p.current == ';') {
@@ -800,7 +809,7 @@ int config_load(struct RastaConfig *config, const char *filename) {
         parser_parseIdentifier(&p, key);
 
         // skip empty start
-        parser_skipBlanc(&p);
+        parser_skipBlank(&p);
 
         if (p.current != '=') {
             logger_log(&p.cfg->logger, LOG_LEVEL_ERROR, p.cfg->filename, "Error in line %d: Expected '=' but found '%c'", p.line, p.current);
@@ -810,7 +819,7 @@ int config_load(struct RastaConfig *config, const char *filename) {
         parser_next(&p);
 
         // skip empty start
-        parser_skipBlanc(&p);
+        parser_skipBlank(&p);
 
         parser_parseValue(&p, key);
 
@@ -832,6 +841,10 @@ struct DictionaryEntry config_get(struct RastaConfig *cfg, const char *key) {
 void config_free(struct RastaConfig *cfg) {
     dictionary_free(&cfg->dictionary);
     if (cfg->values.redundancy.connections.count > 0) free(cfg->values.redundancy.connections.data);
+    if (cfg->values.tls.ca_cert_path != NULL) free(cfg->values.tls.ca_cert_path);
+    if (cfg->values.tls.cert_path != NULL) free(cfg->values.tls.cert_path);
+    if (cfg->values.tls.key_path != NULL) free(cfg->values.tls.key_path);
+    if (cfg->values.tls.peer_tls_cert_path != NULL) free(cfg->values.tls.peer_tls_cert_path);
 }
 
 unsigned long mix(unsigned long a, unsigned long b, unsigned long c) {

--- a/examples/common/c/configfile.c
+++ b/examples/common/c/configfile.c
@@ -662,21 +662,21 @@ void config_setstd(struct RastaConfig *cfg) {
     cfg->values.tls.ca_cert_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
         cfg->values.tls.ca_cert_path = calloc(MAX_DICTIONARY_STRING_LENGTH_BYTES, 1);
-        strncpy(cfg->values.tls.ca_cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES);
+        strncpy(cfg->values.tls.ca_cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES - 1);
     }
 
     entr = config_get(cfg, "RASTA_CERT_PATH");
     cfg->values.tls.cert_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
         cfg->values.tls.cert_path = calloc(MAX_DICTIONARY_STRING_LENGTH_BYTES, 1);
-        strncpy(cfg->values.tls.cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES);
+        strncpy(cfg->values.tls.cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES - 1);
     }
 
     entr = config_get(cfg, "RASTA_KEY_PATH");
     cfg->values.tls.key_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
         cfg->values.tls.key_path = calloc(MAX_DICTIONARY_STRING_LENGTH_BYTES, 1);
-        strncpy(cfg->values.tls.key_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES);
+        strncpy(cfg->values.tls.key_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES - 1);
     }
 
 #ifdef ENABLE_TLS
@@ -689,7 +689,7 @@ void config_setstd(struct RastaConfig *cfg) {
     cfg->values.tls.peer_tls_cert_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
         cfg->values.tls.peer_tls_cert_path = calloc(MAX_DICTIONARY_STRING_LENGTH_BYTES, 1);
-        strncpy(cfg->values.tls.peer_tls_cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES);
+        strncpy(cfg->values.tls.peer_tls_cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES - 1);
     }
 #endif
 

--- a/examples/common/c/configfile.c
+++ b/examples/common/c/configfile.c
@@ -661,21 +661,21 @@ void config_setstd(struct RastaConfig *cfg) {
     entr = config_get(cfg, "RASTA_CA_PATH");
     cfg->values.tls.ca_cert_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
-        cfg->values.tls.ca_cert_path = malloc(MAX_DICTIONARY_STRING_LENGTH_BYTES);
+        cfg->values.tls.ca_cert_path = calloc(MAX_DICTIONARY_STRING_LENGTH_BYTES, 1);
         strncpy(cfg->values.tls.ca_cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES);
     }
 
     entr = config_get(cfg, "RASTA_CERT_PATH");
     cfg->values.tls.cert_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
-        cfg->values.tls.cert_path = malloc(MAX_DICTIONARY_STRING_LENGTH_BYTES);
+        cfg->values.tls.cert_path = calloc(MAX_DICTIONARY_STRING_LENGTH_BYTES, 1);
         strncpy(cfg->values.tls.cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES);
     }
 
     entr = config_get(cfg, "RASTA_KEY_PATH");
     cfg->values.tls.key_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
-        cfg->values.tls.key_path = malloc(MAX_DICTIONARY_STRING_LENGTH_BYTES);
+        cfg->values.tls.key_path = calloc(MAX_DICTIONARY_STRING_LENGTH_BYTES, 1);
         strncpy(cfg->values.tls.key_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES);
     }
 
@@ -688,7 +688,7 @@ void config_setstd(struct RastaConfig *cfg) {
     entr = config_get(cfg, "RASTA_TLS_PEER_CERT_PATH");
     cfg->values.tls.peer_tls_cert_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
-        cfg->values.tls.peer_tls_cert_path = malloc(MAX_DICTIONARY_STRING_LENGTH_BYTES);
+        cfg->values.tls.peer_tls_cert_path = calloc(MAX_DICTIONARY_STRING_LENGTH_BYTES, 1);
         strncpy(cfg->values.tls.peer_tls_cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES);
     }
 #endif

--- a/examples/common/c/configfile.c
+++ b/examples/common/c/configfile.c
@@ -662,21 +662,24 @@ void config_setstd(struct RastaConfig *cfg) {
     cfg->values.tls.ca_cert_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
         cfg->values.tls.ca_cert_path = malloc(MAX_DICTIONARY_STRING_LENGTH_BYTES);
-        strcpy(cfg->values.tls.ca_cert_path, entr.value.string.c);
+        strncpy(cfg->values.tls.ca_cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES);
+        cfg->values.tls.ca_cert_path[MAX_DICTIONARY_STRING_LENGTH_BYTES - 1] = '\0';
     }
 
     entr = config_get(cfg, "RASTA_CERT_PATH");
     cfg->values.tls.cert_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
         cfg->values.tls.cert_path = malloc(MAX_DICTIONARY_STRING_LENGTH_BYTES);
-        strcpy(cfg->values.tls.cert_path, entr.value.string.c);
+        strncpy(cfg->values.tls.cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES);
+        cfg->values.tls.cert_path[MAX_DICTIONARY_STRING_LENGTH_BYTES - 1] = '\0';
     }
 
     entr = config_get(cfg, "RASTA_KEY_PATH");
     cfg->values.tls.key_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
         cfg->values.tls.key_path = malloc(MAX_DICTIONARY_STRING_LENGTH_BYTES);
-        strcpy(cfg->values.tls.key_path, entr.value.string.c);
+        strncpy(cfg->values.tls.key_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES);
+        cfg->values.tls.key_path[MAX_DICTIONARY_STRING_LENGTH_BYTES - 1] = '\0';
     }
 
 #ifdef ENABLE_TLS
@@ -689,7 +692,8 @@ void config_setstd(struct RastaConfig *cfg) {
     cfg->values.tls.peer_tls_cert_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
         cfg->values.tls.peer_tls_cert_path = malloc(MAX_DICTIONARY_STRING_LENGTH_BYTES);
-        strcpy(cfg->values.tls.peer_tls_cert_path, entr.value.string.c);
+        strncpy(cfg->values.tls.peer_tls_cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES);
+        cfg->values.tls.peer_tls_cert_path[MAX_DICTIONARY_STRING_LENGTH_BYTES - 1] = '\0';
     }
 #endif
 

--- a/examples/common/c/configfile.c
+++ b/examples/common/c/configfile.c
@@ -661,22 +661,22 @@ void config_setstd(struct RastaConfig *cfg) {
     entr = config_get(cfg, "RASTA_CA_PATH");
     cfg->values.tls.ca_cert_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
-        cfg->values.tls.ca_cert_path = calloc(MAX_DICTIONARY_STRING_LENGTH_BYTES, 1);
-        strncpy(cfg->values.tls.ca_cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES - 1);
+        cfg->values.tls.ca_cert_path = malloc(MAX_DICTIONARY_STRING_LENGTH_BYTES);
+        strcpy(cfg->values.tls.ca_cert_path, entr.value.string.c);
     }
 
     entr = config_get(cfg, "RASTA_CERT_PATH");
     cfg->values.tls.cert_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
-        cfg->values.tls.cert_path = calloc(MAX_DICTIONARY_STRING_LENGTH_BYTES, 1);
-        strncpy(cfg->values.tls.cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES - 1);
+        cfg->values.tls.cert_path = malloc(MAX_DICTIONARY_STRING_LENGTH_BYTES);
+        strcpy(cfg->values.tls.cert_path, entr.value.string.c);
     }
 
     entr = config_get(cfg, "RASTA_KEY_PATH");
     cfg->values.tls.key_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
-        cfg->values.tls.key_path = calloc(MAX_DICTIONARY_STRING_LENGTH_BYTES, 1);
-        strncpy(cfg->values.tls.key_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES - 1);
+        cfg->values.tls.key_path = malloc(MAX_DICTIONARY_STRING_LENGTH_BYTES);
+        strcpy(cfg->values.tls.key_path, entr.value.string.c);
     }
 
 #ifdef ENABLE_TLS
@@ -688,8 +688,8 @@ void config_setstd(struct RastaConfig *cfg) {
     entr = config_get(cfg, "RASTA_TLS_PEER_CERT_PATH");
     cfg->values.tls.peer_tls_cert_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
-        cfg->values.tls.peer_tls_cert_path = calloc(MAX_DICTIONARY_STRING_LENGTH_BYTES, 1);
-        strncpy(cfg->values.tls.peer_tls_cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES - 1);
+        cfg->values.tls.peer_tls_cert_path = malloc(MAX_DICTIONARY_STRING_LENGTH_BYTES);
+        strcpy(cfg->values.tls.peer_tls_cert_path, entr.value.string.c);
     }
 #endif
 

--- a/examples/common/c/configfile.c
+++ b/examples/common/c/configfile.c
@@ -661,25 +661,22 @@ void config_setstd(struct RastaConfig *cfg) {
     entr = config_get(cfg, "RASTA_CA_PATH");
     cfg->values.tls.ca_cert_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
-        char *ca_path = malloc(strnlen(entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES) + 1);
-        strncpy(ca_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES);
-        cfg->values.tls.ca_cert_path = ca_path;
+        cfg->values.tls.ca_cert_path = malloc(strnlen(entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES));
+        strncpy(cfg->values.tls.ca_cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES - 1);
     }
 
     entr = config_get(cfg, "RASTA_CERT_PATH");
     cfg->values.tls.cert_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
-        char *cert_path = malloc(strnlen(entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES) + 1);
-        strncpy(cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES);
-        cfg->values.tls.cert_path = cert_path;
+        cfg->values.tls.cert_path = malloc(strnlen(entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES));
+        strncpy(cfg->values.tls.cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES - 1);
     }
 
     entr = config_get(cfg, "RASTA_KEY_PATH");
     cfg->values.tls.key_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
-        char *key_path = malloc(strnlen(entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES) + 1);
-        strncpy(key_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES);
-        cfg->values.tls.key_path = key_path;
+        cfg->values.tls.key_path = malloc(strnlen(entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES));
+        strncpy(cfg->values.tls.key_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES - 1);
     }
 
 #ifdef ENABLE_TLS
@@ -691,9 +688,8 @@ void config_setstd(struct RastaConfig *cfg) {
     entr = config_get(cfg, "RASTA_TLS_PEER_CERT_PATH");
     cfg->values.tls.peer_tls_cert_path = NULL;
     if (entr.type == DICTIONARY_STRING) {
-        char *peer_tls_cert_path = malloc(strnlen(entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES) + 1);
-        strncpy(peer_tls_cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES);
-        cfg->values.tls.peer_tls_cert_path = peer_tls_cert_path;
+        cfg->values.tls.peer_tls_cert_path = malloc(strnlen(entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES));
+        strncpy(cfg->values.tls.peer_tls_cert_path, entr.value.string.c, MAX_DICTIONARY_STRING_LENGTH_BYTES - 1);
     }
 #endif
 

--- a/src/c/transport/dtls.c
+++ b/src/c/transport/dtls.c
@@ -115,7 +115,7 @@ static size_t wolfssl_receive_dtls(rasta_transport_socket *transport_socket, uns
 
 static bool is_dtls_server(const rasta_config_tls *tls_config) {
     // client has CA cert but no server certs
-    return tls_config->cert_path[0] && tls_config->key_path[0];
+    return tls_config->cert_path != NULL && tls_config->key_path != NULL;
 }
 
 void handle_tls_mode(rasta_transport_socket *transport_socket) {

--- a/src/c/transport/ssl_utils.c
+++ b/src/c/transport/ssl_utils.c
@@ -41,7 +41,7 @@ void wolfssl_start_server(rasta_transport_socket *transport_socket, const rasta_
         abort();
     }
 
-    if (!tls_config->ca_cert_path[0] || !tls_config->cert_path[0] || !tls_config->key_path[0]) {
+    if (tls_config->ca_cert_path == NULL || tls_config->cert_path == NULL || tls_config->key_path == NULL) {
         fprintf(stderr, "CA certificate path, server certificate path or server private key path missing!\n");
         abort();
     }
@@ -130,7 +130,7 @@ void wolfssl_start_client(WOLFSSL_CTX **ctx, const rasta_config_tls *tls_config,
         abort();
     }
 
-    if (!tls_config->ca_cert_path[0]) {
+    if (!tls_config->ca_cert_path != NULL) {
         fprintf(stderr, "CA certificate path missing!\n");
         abort();
     }
@@ -143,7 +143,7 @@ void wolfssl_start_client(WOLFSSL_CTX **ctx, const rasta_config_tls *tls_config,
         abort();
     }
 
-    if (tls_config->cert_path[0] && tls_config->key_path[0]) {
+    if (tls_config->cert_path != NULL && tls_config->key_path != NULL) {
         /* Load client certificates */
         if (wolfSSL_CTX_use_certificate_file(*ctx, tls_config->cert_path, SSL_FILETYPE_PEM) !=
             SSL_SUCCESS) {
@@ -263,7 +263,7 @@ void generate_certificate_digest(WOLFSSL_X509 *peer_cert,
 }
 
 void tls_pin_certificate(WOLFSSL *ssl, const char *peer_tls_cert_path) {
-    if (peer_tls_cert_path[0]) {
+    if (peer_tls_cert_path != NULL) {
         // public key pinning: check TLS public key of peer
         unsigned char peer_digest_buffer[SHA256_BUFFER_LENGTH_BYTES], pinned_digest_buffer[SHA256_BUFFER_LENGTH_BYTES];
         unsigned int peer_digest_buffer_size, pinned_digest_buffer_size;

--- a/src/c/transport/ssl_utils.c
+++ b/src/c/transport/ssl_utils.c
@@ -130,7 +130,7 @@ void wolfssl_start_client(WOLFSSL_CTX **ctx, const rasta_config_tls *tls_config,
         abort();
     }
 
-    if (!tls_config->ca_cert_path != NULL) {
+    if (tls_config->ca_cert_path == NULL) {
         fprintf(stderr, "CA certificate path missing!\n");
         abort();
     }

--- a/src/include/rasta/config.h
+++ b/src/include/rasta/config.h
@@ -213,20 +213,19 @@ typedef struct rasta_config_general {
 /**
  * Non-standard extension
  */
-// TODO: PATH_MAX is Linux-specific, replace if possible
 typedef struct rasta_config_tls {
     /**
      * Path to CA certificate to use, required for server and client operation
      */
-    char ca_cert_path[PATH_MAX];
+    char *ca_cert_path;
     /**
      * Path to server certificate to use, required for server and client operation
      */
-    char cert_path[PATH_MAX];
+    char *cert_path;
     /**
      * Path to server private key to use, required for server operation
      */
-    char key_path[PATH_MAX];
+    char *key_path;
     /**
      * Domain / common name to validate TLS certificates against (as client)
      */
@@ -234,7 +233,7 @@ typedef struct rasta_config_tls {
     /**
      * path to peer certificate for certificate pinning. Optional.
      */
-    char peer_tls_cert_path[PATH_MAX];
+    char *peer_tls_cert_path;
 } rasta_config_tls;
 
 /**

--- a/src/include/rasta/config.h
+++ b/src/include/rasta/config.h
@@ -5,7 +5,6 @@ extern "C" { // only need to export C interface if
              // used by C++ source code
 #endif
 
-#include <limits.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>


### PR DESCRIPTION
For cross-platform use, it's cumbersome that we were using PATH MAX to define the size of the config struct.
That's because PATH_MAX is defined differently for each platform (Linux, macOS, Windows).

Generally, the concept of PATH_MAX seems to be tricky: https://eklitzke.org/path-max-is-tricky

I've therefore changed the way that memory for the file paths within the config is handled: now, the caller (most often: configfile.c) is responsible for allocating and freeing memory for file paths and just registers a pointer within the config struct.