### PR TITLE
Fix sequence number initialization when handling connection request

### DIFF
--- a/src/c/retransmission/handlers.c
+++ b/src/c/retransmission/handlers.c
@@ -383,7 +383,7 @@ void handle_conreq(struct rasta_connection *connection, struct RastaPacket *rece
         sr_init_connection(connection, RASTA_ROLE_SERVER);
 
         // initialize seq num
-        connection->sn_t = connection->sn_i = receivedPacket->sequence_number;
+        connection->sn_t = connection->sn_i = connection->config->initial_sequence_number;
 
         logger_log(connection->logger, LOG_LEVEL_DEBUG, "RaSTA HANDLE: ConnectionRequest", "Using %lu as initial sequence number",
                    (long unsigned int)connection->sn_t);

--- a/test/rasta_test/c/register_tests.c
+++ b/test/rasta_test/c/register_tests.c
@@ -84,6 +84,7 @@ void cunit_register() {
     // Tests for Safety and Retransmission layer
     CU_add_test(pSuiteRasta, "test_sr_retransmit_data_shouldSendFinalHeartbeat", test_sr_retransmit_data_shouldSendFinalHeartbeat);
     CU_add_test(pSuiteRasta, "test_sr_retransmit_data_shouldRetransmitPackage", test_sr_retransmit_data_shouldRetransmitPackage);
+    CU_add_test(pSuiteRasta, "test_sr_handle_conreq_shouldInitializeSequenceNumberFromConfig", test_sr_handle_conreq_shouldInitializeSequenceNumberFromConfig);
 
     CU_add_test(pSuiteRasta, "test_redundancy_channel", test_redundancy_channel);
 

--- a/test/rasta_test/c/safety_retransmission_test.c
+++ b/test/rasta_test/c/safety_retransmission_test.c
@@ -267,7 +267,7 @@ void test_sr_handle_conreq_shouldInitializeSequenceNumberFromConfig() {
     rasta_md4_set_key(&hashing_context, 0, 0, 0, 0);
     h.hashing_context = &hashing_context;
 
-    char* version = "0303";
+    char *version = "0303";
     struct RastaPacket data = createConnectionRequest(SERVER_ID, CLIENT_ID, 0, 0, 0, version, &hashing_context);
     data.checksum_correct = true;
 

--- a/test/rasta_test/headers/safety_retransmission_test.h
+++ b/test/rasta_test/headers/safety_retransmission_test.h
@@ -1,3 +1,4 @@
 #pragma once
 void test_sr_retransmit_data_shouldSendFinalHeartbeat();
 void test_sr_retransmit_data_shouldRetransmitPackage();
+void test_sr_handle_conreq_shouldInitializeSequenceNumberFromConfig();


### PR DESCRIPTION
Previously, instead of using the preconfigured initial sequence number, the connection request handler would copy the sequence number from the request package to initialize its own sequence number counter.

Now, the value from the config file is used. Note that even when supplying 0 (i.e. 'use random') as the initial sequence number, the same initial sequence number will be used for subsequent connections.