### PR TITLE
Fixed Message Handling for DiscReq messages.

### DIFF
--- a/src/c/retransmission/handlers.c
+++ b/src/c/retransmission/handlers.c
@@ -51,6 +51,11 @@ void update_confirmed_attrs(struct rasta_connection *connection, struct RastaPac
 int handle_discreq(struct rasta_connection *connection, struct RastaPacket *receivedPacket) {
     logger_log(connection->logger, LOG_LEVEL_INFO, "RaSTA HANDLE: DisconnectionRequest", "received DiscReq");
 
+    // 5.6.2 requires updating values according to [1] (CS_T = SN_PDU)
+    // But: DiscReq messages are not confirmed and necessarily last. DiscReq message carry relevant CS/CTS values.
+    update_confirmed_attrs(connection, receivedPacket);
+    sr_remove_confirmed_messages(connection);
+
     connection->current_state = RASTA_CONNECTION_CLOSED;
     sr_reset_connection(connection);
 

--- a/src/c/retransmission/handlers.c
+++ b/src/c/retransmission/handlers.c
@@ -54,7 +54,6 @@ int handle_discreq(struct rasta_connection *connection, struct RastaPacket *rece
     // 5.6.2 requires updating values according to [1] (CS_T = SN_PDU)
     // But: DiscReq messages are not confirmed and necessarily last. DiscReq message carry relevant CS values.
     connection->cs_r = receivedPacket->confirmed_sequence_number;
-
     sr_remove_confirmed_messages(connection);
 
     connection->current_state = RASTA_CONNECTION_CLOSED;

--- a/src/c/retransmission/handlers.c
+++ b/src/c/retransmission/handlers.c
@@ -52,8 +52,9 @@ int handle_discreq(struct rasta_connection *connection, struct RastaPacket *rece
     logger_log(connection->logger, LOG_LEVEL_INFO, "RaSTA HANDLE: DisconnectionRequest", "received DiscReq");
 
     // 5.6.2 requires updating values according to [1] (CS_T = SN_PDU)
-    // But: DiscReq messages are not confirmed and necessarily last. DiscReq message carry relevant CS/CTS values.
-    update_confirmed_attrs(connection, receivedPacket);
+    // But: DiscReq messages are not confirmed and necessarily last. DiscReq message carry relevant CS values.
+    connection->cs_r = receivedPacket->confirmed_sequence_number;
+
     sr_remove_confirmed_messages(connection);
 
     connection->current_state = RASTA_CONNECTION_CLOSED;


### PR DESCRIPTION
Hi! I would like to propose a change for the handling of DiscReq messages. 

## Proposed Change
On receiving a DiscReq message, the receiver should evaluate $CS_{PDU}$ and remove acknowledged messages from the retransmission buffer.

## Reasoning
RaSTA's specification defines in Section 5.6.2 that whenever a DiscReq message is received, the next sequence number to confirm should be updated with the received sequence number of the DiscReq message, $CS_{T} = SN_{PDU}$. This, however, is superfluous, as a party will never send a message after receiving a DiscReq message. Instead, this received DiscReq message contains a confirmed timestamp ($CTS_{PDU}$) and sequence number ($CS_{PDU}$) itself which are not evaluated. If a message now resides in the retransmission buffer when the DiscReq message arrives, the application layer has no means to tell whether this buffered message was received successfully or not, although the DiscReq message contains that data. 

In the end, this change prevents the application from causing undetected message loss / unintended repetition.

I am very happy for any comments or suggestions!
